### PR TITLE
refactor:ROLE 승급 내용 삭제

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/Member/Member.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/Member.java
@@ -53,38 +53,22 @@ public class Member extends BaseTimeStatusEntity {
   }
 
   // ==========================================
-  // 4. 정적 팩토리 메서드 (안전한 객체 생성 보장)
+  // 4. 정적 팩토리 메서드
   // ==========================================
 
   /** 디폴트 생성자 */
   public static Member createNewMember(String nickname, String profileImage) {
     return Member.builder()
-        .memberKey(UuidCreator.getTimeOrderedEpoch())
-        .nickname(nickname)
-        .profileImage(getOrDefaultImage(profileImage))
-        .role(Role.ROLE_USER)
-        .build();
-  }
-
-  /** 카카오 등 소셜 로그인 최초 접근 시 사용 (GUEST 권한 부여) */
-  public static Member createGuest(String temporaryNickname) {
-    return Member.builder()
-        .memberKey(UuidCreator.getTimeOrderedEpoch())
-        .nickname(temporaryNickname) // 카카오 소셜 로그인 응답으로 오는 식별자 id 값을 임시로 넣음.
-        .role(Role.ROLE_GUEST) // 추가 정보 입력 전까지 사용할 권한
-        .build();
+            .memberKey(UuidCreator.getTimeOrderedEpoch())
+            .nickname(nickname)
+            .profileImage(getOrDefaultImage(profileImage))
+            .role(Role.ROLE_USER)
+            .build();
   }
 
   // ==========================================
   // 5. 비즈니스 메서드
   // ==========================================
-
-  /** 소셜 로그인 후 추가 정보 입력 시 정회원(USER)으로 승격 */
-  public void completeSignUp(String nickname, String profileImage) {
-    this.nickname = nickname; // 시용자에게 직접 입력받음.
-    this.profileImage = getOrDefaultImage(profileImage); // 시용자에게 직접 입력받음.
-    this.role = Role.ROLE_USER; // 추가정보 입력후 정회원 승격
-  }
 
   /** 기본 프로필 이미지 설정 */
   private static String getOrDefaultImage(String imageUrl) {

--- a/src/main/java/com/plog/plogbackend/domain/Member/Member.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/Member.java
@@ -59,11 +59,11 @@ public class Member extends BaseTimeStatusEntity {
   /** 디폴트 생성자 */
   public static Member createNewMember(String nickname, String profileImage) {
     return Member.builder()
-            .memberKey(UuidCreator.getTimeOrderedEpoch())
-            .nickname(nickname)
-            .profileImage(getOrDefaultImage(profileImage))
-            .role(Role.ROLE_USER)
-            .build();
+        .memberKey(UuidCreator.getTimeOrderedEpoch())
+        .nickname(nickname)
+        .profileImage(getOrDefaultImage(profileImage))
+        .role(Role.ROLE_USER)
+        .build();
   }
 
   // ==========================================


### PR DESCRIPTION
회원가입 로직을
기존 카카오 인증 -> ROLE_GUEST 권한으로 Member 생성 -> 닉네임 , 프로필 이미지 입력 -> ROLE_USER 로 승격 

이었는데 굳이 Member 생성하고 ROLE 바꾸고 하면 시큐리티 설정이 복잡해지고, ROLE_GUEST 권한 주고, DB에 기본정보 입력하고 JWT 도 발급 해야하기때문에 여러 소요가 많아서

임시 JWT 방식을 도입했습니다.

변경 사항은 Member의 ROLE 승급 메서드와 DB 입력 삭제뿐이라 다른 도메인이나 객체에 영향은 없습니다