### PR TITLE
Feature/post Enum 타입의 api 안전성 향상 및 TimePickerRequest Dto 생성 

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/TimePickerRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/TimePickerRequest.java
@@ -1,0 +1,14 @@
+package com.plog.plogbackend.domain.post.controller.dto.request.post;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+/**
+ * 타임 피커는 {hour: 12, minute: 30}을 전송합니다
+ * 이에 맞게 TimePicker용 DTO를 만들었습니다
+ * @param hour
+ * @param minute
+ */
+public record TimePickerRequest(
+        @Min(0) @Max(23) Integer hour,
+        @Min(0) @Max(59) Integer minute) {}

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/TimePickerRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/TimePickerRequest.java
@@ -4,11 +4,9 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 /**
- * 타임 피커는 {hour: 12, minute: 30}을 전송합니다
- * 이에 맞게 TimePicker용 DTO를 만들었습니다
+ * 타임 피커는 {hour: 12, minute: 30}을 전송합니다 이에 맞게 TimePicker용 DTO를 만들었습니다
+ *
  * @param hour
  * @param minute
  */
-public record TimePickerRequest(
-        @Min(0) @Max(23) Integer hour,
-        @Min(0) @Max(59) Integer minute) {}
+public record TimePickerRequest(@Min(0) @Max(23) Integer hour, @Min(0) @Max(59) Integer minute) {}

--- a/src/main/java/com/plog/plogbackend/domain/post/entity/PublicScope.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/entity/PublicScope.java
@@ -1,6 +1,13 @@
 package com.plog.plogbackend.domain.post.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum PublicScope {
   PUBLIC,
-  PRIVATE
+  PRIVATE;
+
+    @JsonCreator
+    public static PublicScope from(String value) {
+        return valueOf(value.toUpperCase());
+    }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/entity/PublicScope.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/entity/PublicScope.java
@@ -6,8 +6,8 @@ public enum PublicScope {
   PUBLIC,
   PRIVATE;
 
-    @JsonCreator
-    public static PublicScope from(String value) {
-        return valueOf(value.toUpperCase());
-    }
+  @JsonCreator
+  public static PublicScope from(String value) {
+    return valueOf(value.toUpperCase());
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/tag/enums/PlaceTag.java
+++ b/src/main/java/com/plog/plogbackend/domain/tag/enums/PlaceTag.java
@@ -76,20 +76,19 @@ public enum PlaceTag {
     return status;
   }
 
-    /**
-     * good_vibe -> GOOD_VIBE로 바꿔주는 역할
-     * from 메소드명은 관례상 사용하였으며
-     * @JsonCreator를 붙이면 잭슨 라이브러리가
-     * 자동으로 호출해서 대문자로 바꿔줍니다
-     * @param value
-     * @return
-     */
-    @JsonCreator
-    public static PlaceTag from(String value) {
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-        // 프론트에서 "good_vibe"라고 소문자로 보내도 대문자로 바꿔서 매핑해줌
-        return valueOf(value.toUpperCase());
+  /**
+   * good_vibe -> GOOD_VIBE로 바꿔주는 역할 from 메소드명은 관례상 사용하였으며 @JsonCreator를 붙이면 잭슨 라이브러리가 자동으로 호출해서
+   * 대문자로 바꿔줍니다
+   *
+   * @param value
+   * @return
+   */
+  @JsonCreator
+  public static PlaceTag from(String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
     }
+    // 프론트에서 "good_vibe"라고 소문자로 보내도 대문자로 바꿔서 매핑해줌
+    return valueOf(value.toUpperCase());
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/tag/enums/PlaceTag.java
+++ b/src/main/java/com/plog/plogbackend/domain/tag/enums/PlaceTag.java
@@ -1,5 +1,7 @@
 package com.plog.plogbackend.domain.tag.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum PlaceTag {
   GOOD_VIBE("ATMOSPHERE_AND_FOCUS"),
   NOISY("ATMOSPHERE_AND_FOCUS"),
@@ -73,4 +75,21 @@ public enum PlaceTag {
   public String getStatus() {
     return status;
   }
+
+    /**
+     * good_vibe -> GOOD_VIBE로 바꿔주는 역할
+     * from 메소드명은 관례상 사용하였으며
+     * @JsonCreator를 붙이면 잭슨 라이브러리가
+     * 자동으로 호출해서 대문자로 바꿔줍니다
+     * @param value
+     * @return
+     */
+    @JsonCreator
+    public static PlaceTag from(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        // 프론트에서 "good_vibe"라고 소문자로 보내도 대문자로 바꿔서 매핑해줌
+        return valueOf(value.toUpperCase());
+    }
 }


### PR DESCRIPTION
타입 안정성을 위해 @JsonCreator를 사용해 소문자로 api를 받아도 대문자 필드명인 enum가 같게 매칭할 수 있게 하였습니다 
TimePicker로 공부 스터디 시작시간과 스터디 마감시간을 전송하게 되는데 해당 Dto를 받을 record 클래스 추가했습니다. 