### PR TITLE
perf:모든 영어문장 차단하는 버그 해결, 정규표현식 탐지 성능 개선

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
@@ -16,6 +16,8 @@ import com.plog.plogbackend.global.error.ErrorType;
 import com.plog.plogbackend.security.jwt.JwtProvider;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,6 +32,11 @@ public class MemberService {
 
   /** 첫 로그인(회원가입) 뱃지 ID */
   private static final long BADGE_ID_FIRST_LOGIN = 1L;
+
+  /** 유효성 검사 패턴. (메모리 낭비 방지) */
+  private static final Pattern PHONE_PATTERN = Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
+  private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+  private static final Pattern SNS_PATTERN = Pattern.compile("kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
 
   private final MemberRepository memberRepository;
   private final JwtProvider jwtProvider;
@@ -214,6 +221,27 @@ public class MemberService {
     }
   }
 
+//  /** 소개글 유효성 검사 (개인정보 및 SNS 방지) */
+//  public void validateIntroduction(String introduction) {
+//    if (introduction == null || introduction.isBlank()) {
+//      return;
+//    }
+//
+//    String lowerIntro = introduction.toLowerCase();
+//    boolean hasPhoneNumber =
+//        lowerIntro.matches(".*(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}.*");
+//    boolean hasEmail = lowerIntro.matches(".*[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}.*");
+//    boolean hasSnsKeyword =
+//        lowerIntro.matches(
+//                ".*(kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}).*");
+//
+//    if (hasPhoneNumber || hasEmail || hasSnsKeyword) {
+//      throw new AppException(ErrorType.INVALID_INTRODUCTION_FORMAT);
+//    }
+//
+//    // 금칙어 검사
+//    badWordFilterService.validate(introduction);
+//  }
   /** 소개글 유효성 검사 (개인정보 및 SNS 방지) */
   public void validateIntroduction(String introduction) {
     if (introduction == null || introduction.isBlank()) {
@@ -221,12 +249,11 @@ public class MemberService {
     }
 
     String lowerIntro = introduction.toLowerCase();
-    boolean hasPhoneNumber =
-        lowerIntro.matches(".*(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}.*");
-    boolean hasEmail = lowerIntro.matches(".*[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}.*");
-    boolean hasSnsKeyword =
-        lowerIntro.matches(
-            ".*(kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@*[a-zA-Z0-9._%+-]).*");
+
+    // 2. matches(".*패턴.*") 대신 부분 검색에 최적화된 matcher().find() 사용
+    boolean hasPhoneNumber = PHONE_PATTERN.matcher(lowerIntro).find();
+    boolean hasEmail = EMAIL_PATTERN.matcher(lowerIntro).find();
+    boolean hasSnsKeyword = SNS_PATTERN.matcher(lowerIntro).find();
 
     if (hasPhoneNumber || hasEmail || hasSnsKeyword) {
       throw new AppException(ErrorType.INVALID_INTRODUCTION_FORMAT);

--- a/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
@@ -17,7 +17,6 @@ import com.plog.plogbackend.security.jwt.JwtProvider;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -34,9 +33,14 @@ public class MemberService {
   private static final long BADGE_ID_FIRST_LOGIN = 1L;
 
   /** 유효성 검사 패턴. (메모리 낭비 방지) */
-  private static final Pattern PHONE_PATTERN = Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
-  private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
-  private static final Pattern SNS_PATTERN = Pattern.compile("kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
+  private static final Pattern PHONE_PATTERN =
+      Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
+
+  private static final Pattern EMAIL_PATTERN =
+      Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+  private static final Pattern SNS_PATTERN =
+      Pattern.compile(
+          "kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
 
   private final MemberRepository memberRepository;
   private final JwtProvider jwtProvider;
@@ -221,27 +225,6 @@ public class MemberService {
     }
   }
 
-//  /** 소개글 유효성 검사 (개인정보 및 SNS 방지) */
-//  public void validateIntroduction(String introduction) {
-//    if (introduction == null || introduction.isBlank()) {
-//      return;
-//    }
-//
-//    String lowerIntro = introduction.toLowerCase();
-//    boolean hasPhoneNumber =
-//        lowerIntro.matches(".*(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}.*");
-//    boolean hasEmail = lowerIntro.matches(".*[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}.*");
-//    boolean hasSnsKeyword =
-//        lowerIntro.matches(
-//                ".*(kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}).*");
-//
-//    if (hasPhoneNumber || hasEmail || hasSnsKeyword) {
-//      throw new AppException(ErrorType.INVALID_INTRODUCTION_FORMAT);
-//    }
-//
-//    // 금칙어 검사
-//    badWordFilterService.validate(introduction);
-//  }
   /** 소개글 유효성 검사 (개인정보 및 SNS 방지) */
   public void validateIntroduction(String introduction) {
     if (introduction == null || introduction.isBlank()) {

--- a/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
@@ -233,7 +233,6 @@ public class MemberService {
 
     String lowerIntro = introduction.toLowerCase();
 
-    // 2. matches(".*패턴.*") 대신 부분 검색에 최적화된 matcher().find() 사용
     boolean hasPhoneNumber = PHONE_PATTERN.matcher(lowerIntro).find();
     boolean hasEmail = EMAIL_PATTERN.matcher(lowerIntro).find();
     boolean hasSnsKeyword = SNS_PATTERN.matcher(lowerIntro).find();


### PR DESCRIPTION
소개글에서, 이메일이나 소셜 아이디 형식이 아닌 qwer 같은 영어글을 유효성 검사시, 무조건 차단하는 버그를 개선하였습니다.