### PR TITLE
feat:하드 딜리트 회원탈퇴 구현 및 요청 크기 제한 상향 

### DIFF
--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -1,6 +1,8 @@
 server {
     listen 80;
 
+    client_max_body_size 60M;
+
     location ~* \.(php|asp|aspx|jsp|env|cgi|bak|log)$ {
         return 444;
     }

--- a/src/main/java/com/plog/plogbackend/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/controller/MemberController.java
@@ -6,13 +6,16 @@ import com.plog.plogbackend.domain.Member.dto.response.MemberResponse;
 import com.plog.plogbackend.domain.Member.service.MemberImageService;
 import com.plog.plogbackend.domain.Member.service.MemberService;
 import com.plog.plogbackend.global.response.ApiResponse;
+import com.plog.plogbackend.global.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -27,6 +30,7 @@ public class MemberController {
 
   private final MemberImageService memberImageService;
   private final MemberService memberService;
+  private final CookieUtil cookieUtil;
 
   @Operation( // TODO : 회원 정보 조회 엔드포인트. 사용처 없으면 삭제
       summary = "회원 정보 조회",
@@ -101,6 +105,27 @@ public class MemberController {
   public ResponseEntity<ApiResponse<Void>> validateIntroduction(
       @Parameter(description = "검사할 소개글") @RequestParam("introduction") String introduction) {
     memberService.validateIntroduction(introduction);
+    return ResponseEntity.ok(ApiResponse.success());
+  }
+
+  @Operation(
+      summary = "회원 탈퇴",
+      description = "로그인한 회원 정보와 작성한 모든 게시글, 북마크, 좋아요, 배지 등 모든 연관 데이터를 " +
+          "소프트 딜리트 없이 완전히 삭제(하드 딜리트)합니다. " +
+          "리프레시 토큰 DB 삭제 및 쿠키(액세스/리프레시 토큰)도 함께 제거합니다."+
+          "이미지 삭제는 가장 마지막에 이루어집니다.")
+  @DeleteMapping("/me")
+  public ResponseEntity<ApiResponse<Void>> withdraw(
+      Authentication authentication,
+      HttpServletResponse response) {
+    UUID memberKey = (UUID) authentication.getPrincipal();
+
+    memberService.withdraw(memberKey);
+
+    // 쿠키 초기화 (서비스에서 HttpServletResponse 접근 불가능하므로 컨트롤러에서 처리)
+    response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.deleteCookie("accessToken").toString());
+    response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.deleteCookie("refreshToken").toString());
+
     return ResponseEntity.ok(ApiResponse.success());
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/controller/MemberController.java
@@ -110,14 +110,14 @@ public class MemberController {
 
   @Operation(
       summary = "회원 탈퇴",
-      description = "로그인한 회원 정보와 작성한 모든 게시글, 북마크, 좋아요, 배지 등 모든 연관 데이터를 " +
-          "소프트 딜리트 없이 완전히 삭제(하드 딜리트)합니다. " +
-          "리프레시 토큰 DB 삭제 및 쿠키(액세스/리프레시 토큰)도 함께 제거합니다."+
-          "이미지 삭제는 가장 마지막에 이루어집니다.")
+      description =
+          "로그인한 회원 정보와 작성한 모든 게시글, 북마크, 좋아요, 배지 등 모든 연관 데이터를 "
+              + "소프트 딜리트 없이 완전히 삭제(하드 딜리트)합니다. "
+              + "리프레시 토큰 DB 삭제 및 쿠키(액세스/리프레시 토큰)도 함께 제거합니다."
+              + "이미지 삭제는 가장 마지막에 이루어집니다.")
   @DeleteMapping("/me")
   public ResponseEntity<ApiResponse<Void>> withdraw(
-      Authentication authentication,
-      HttpServletResponse response) {
+      Authentication authentication, HttpServletResponse response) {
     UUID memberKey = (UUID) authentication.getPrincipal();
 
     memberService.withdraw(memberKey);

--- a/src/main/java/com/plog/plogbackend/domain/Member/repository/MemberAgreementRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/repository/MemberAgreementRepository.java
@@ -2,5 +2,12 @@ package com.plog.plogbackend.domain.Member.repository;
 
 import com.plog.plogbackend.domain.Member.MemberAgreement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface MemberAgreementRepository extends JpaRepository<MemberAgreement, Long> {}
+public interface MemberAgreementRepository extends JpaRepository<MemberAgreement, Long> {
+
+  @Modifying
+  @Query("DELETE FROM MemberAgreement ma WHERE ma.member.id = :memberId")
+  void deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
@@ -47,11 +47,14 @@ public class MemberService {
   private static final long BADGE_ID_FIRST_LOGIN = 1L;
 
   /** 유효성 검사 패턴. (메모리 낭비 방지) */
-  private static final Pattern PHONE_PATTERN = Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
+  private static final Pattern PHONE_PATTERN =
+      Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
 
-  private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
-  private static final Pattern SNS_PATTERN = Pattern.compile(
-      "kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
+  private static final Pattern EMAIL_PATTERN =
+      Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+  private static final Pattern SNS_PATTERN =
+      Pattern.compile(
+          "kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
 
   private final MemberRepository memberRepository;
   private final JwtProvider jwtProvider;
@@ -78,13 +81,12 @@ public class MemberService {
   /**
    * 회원가입을 처리합니다.
    *
-   * <p>
-   * 프로필 이미지는 파일 업로드 또는 기본 이미지 URL 중 하나를 반드시 제공해야 합니다. 이미지 결정은 {@link
+   * <p>프로필 이미지는 파일 업로드 또는 기본 이미지 URL 중 하나를 반드시 제공해야 합니다. 이미지 결정은 {@link
    * MemberImageService#resolveSignupProfileImage}에 위임합니다.
    *
-   * @param registerToken  카카오 인증 후 발급된 임시 가입 토큰
-   * @param request        닉네임, 약관동의 정보
-   * @param profileImage   직접 업로드할 이미지 파일 (nullable)
+   * @param registerToken 카카오 인증 후 발급된 임시 가입 토큰
+   * @param request 닉네임, 약관동의 정보
+   * @param profileImage 직접 업로드할 이미지 파일 (nullable)
    * @param defaultImageId 기본 이미지 ID (profileImage가 없을 때 사용, nullable)
    * @return 생성된 회원의 memberKey
    */
@@ -109,27 +111,31 @@ public class MemberService {
     validateIntroduction(request.introduction());
 
     // 파일 또는 기본 이미지 ID 중 하나는 반드시 있어야 함 (없으면 FILE_EMPTY 예외)
-    String profileImageUrl = memberImageService.resolveSignupProfileImage(profileImage, defaultImageId);
+    String profileImageUrl =
+        memberImageService.resolveSignupProfileImage(profileImage, defaultImageId);
 
-    Member member = Member.createNewMember(
-        request.nickname(), providerId, profileImageUrl, request.introduction());
+    Member member =
+        Member.createNewMember(
+            request.nickname(), providerId, profileImageUrl, request.introduction());
     memberRepository.save(member);
 
     if (request.termsAgreements() != null) {
       for (Map.Entry<String, Boolean> entry : request.termsAgreements().entrySet()) {
-        Terms terms = termsRepository
-            .findByName(entry.getKey())
-            .orElseThrow(() -> new AppException(ErrorType.TERMS_NOT_FOUND));
+        Terms terms =
+            termsRepository
+                .findByName(entry.getKey())
+                .orElseThrow(() -> new AppException(ErrorType.TERMS_NOT_FOUND));
 
         if (terms.isRequired() && !entry.getValue()) {
           throw new AppException(ErrorType.REQUIRED_TERMS_NOT_AGREED);
         }
 
-        MemberAgreement agreement = MemberAgreement.builder()
-            .member(member)
-            .terms(terms)
-            .isAgreed(entry.getValue())
-            .build();
+        MemberAgreement agreement =
+            MemberAgreement.builder()
+                .member(member)
+                .terms(terms)
+                .isAgreed(entry.getValue())
+                .build();
         memberAgreementRepository.save(agreement);
       }
     }
@@ -149,9 +155,10 @@ public class MemberService {
    */
   @Transactional(readOnly = true)
   public MemberResponse getMyPageInfo(UUID memberKey) {
-    Member member = memberRepository
-        .findByMemberKey(memberKey)
-        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+    Member member =
+        memberRepository
+            .findByMemberKey(memberKey)
+            .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
 
     MemberBadgeResponse badgeResponse = null;
     if (member.getMainBadge() != null) {
@@ -169,35 +176,34 @@ public class MemberService {
   /**
    * 프로필(닉네임 + 이미지)을 한 번에 수정합니다.
    *
-   * <p>
-   * 이미지가 제공된 경우:
+   * <p>이미지가 제공된 경우:
    *
    * <ul>
-   * <li>파일이면 GCS에 업로드 후 URL 저장, 기존 커스텀 이미지는 커밋 후 GCS 삭제
-   * <li>기본 이미지 ID이면 DB 검증 후 해당 URL로 교체
+   *   <li>파일이면 GCS에 업로드 후 URL 저장, 기존 커스텀 이미지는 커밋 후 GCS 삭제
+   *   <li>기본 이미지 ID이면 DB 검증 후 해당 URL로 교체
    * </ul>
    *
-   * <p>
-   * 닉네임이 null 또는 빈 값이면 닉네임은 변경하지 않습니다.
+   * <p>닉네임이 null 또는 빈 값이면 닉네임은 변경하지 않습니다.
    *
-   * <p>
-   * 이미지가 null이고 defaultImageId도 null이면 이미지는 변경하지 않습니다.
+   * <p>이미지가 null이고 defaultImageId도 null이면 이미지는 변경하지 않습니다.
    *
-   * @param memberKey      회원 UUID
-   * @param request        닉네임 변경 정보 (nullable 허용)
-   * @param file           업로드할 이미지 파일 (nullable)
+   * @param memberKey 회원 UUID
+   * @param request 닉네임 변경 정보 (nullable 허용)
+   * @param file 업로드할 이미지 파일 (nullable)
    * @param defaultImageId 기본 이미지 ID (file이 없을 때 사용, nullable)
    */
   @Transactional
   public void updateProfile(
       UUID memberKey, UpdateProfileRequest request, MultipartFile file, Long defaultImageId) {
 
-    Member member = memberRepository
-        .findByMemberKey(memberKey)
-        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+    Member member =
+        memberRepository
+            .findByMemberKey(memberKey)
+            .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
 
     // 이미지 변경 처리 (변경 없으면 null 반환)
-    String newImageUrl = memberImageService.resolveAndScheduleImageUpdate(member, file, defaultImageId);
+    String newImageUrl =
+        memberImageService.resolveAndScheduleImageUpdate(member, file, defaultImageId);
 
     String newNickname = request.nickname();
     String newIntroduction = request.introduction();
@@ -268,14 +274,8 @@ public class MemberService {
   /**
    * 회원 탈퇴 - 하드 딜리트
    *
-   * <p>삭제 순서:
-   * 1) 리프레시 토큰 DB 삭제
-   * 2) 최근 장소 검색 기록 삭제
-   * 3) 회원이 누른 좋아요/북마크 삭제
-   * 4) 획득 배지·약관 동의 내역 삭제
-   * 5) 작성 게시글 하위 데이터 + GCS 파일 + 게시글 삭제
-   * 6) GCS 프로필 이미지 삭제
-   * 7) flush & clear → Member DB 삭제 (영속성 충돌 해소)
+   * <p>삭제 순서: 1) 리프레시 토큰 DB 삭제 2) 최근 장소 검색 기록 삭제 3) 회원이 누른 좋아요/북마크 삭제 4) 획득 배지·약관 동의 내역 삭제 5) 작성
+   * 게시글 하위 데이터 + GCS 파일 + 게시글 삭제 6) GCS 프로필 이미지 삭제 7) flush & clear → Member DB 삭제 (영속성 충돌 해소)
    *
    * <p>쿠키 초기화는 호출 측 컨트롤러에서 HttpServletResponse로 처리한다.
    *
@@ -283,8 +283,10 @@ public class MemberService {
    */
   @Transactional
   public void withdraw(UUID memberKey) {
-    Member member = memberRepository.findByMemberKey(memberKey)
-        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+    Member member =
+        memberRepository
+            .findByMemberKey(memberKey)
+            .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
 
     Long memberId = member.getId();
     String profileImageUrl = member.getProfileImage(); // 프로필 삭제하기 전에 프로필 사진 수집
@@ -310,13 +312,15 @@ public class MemberService {
       List<Long> postIds = myPosts.stream().map(Post::getId).collect(Collectors.toList());
 
       // GCS 삭제를 위해 URL만 미리 수집
-      postImageUrls = postImageRepository.findAllByPostIdIn(postIds)
-          .stream().map(PostImage::getImageUrl).collect(Collectors.toList());
+      postImageUrls =
+          postImageRepository.findAllByPostIdIn(postIds).stream()
+              .map(PostImage::getImageUrl)
+              .collect(Collectors.toList());
 
       // 하위 레코드 bulk JPQL delete
       postImageRepository.deleteAllByPostIdIn(postIds);
       postTagRepository.deleteAllByPostIdIn(postIds);
-      likeRepository.deleteAllByPostIdIn(postIds);   // 어떤 타 회원의 좋아요도 있을 수 있음
+      likeRepository.deleteAllByPostIdIn(postIds); // 어떤 타 회원의 좋아요도 있을 수 있음
       bookMarkRepository.deleteAllByPostIdIn(postIds); // 같은 이유
 
       // 게시글 bulk delete
@@ -333,13 +337,14 @@ public class MemberService {
 
     // 7. DB 삭제가 완전히 완료된 후 GCS 파일 삭제
     final List<String> finalPostImageUrls = postImageUrls;
-    finalPostImageUrls.forEach(url -> {
-      try {
-        gcsService.delete(url);
-      } catch (Exception e) {
-        log.warn("게시글 이미지 GCS 삭제 실패 - url: {}, error: {}", url, e.getMessage());
-      }
-    });
+    finalPostImageUrls.forEach(
+        url -> {
+          try {
+            gcsService.delete(url);
+          } catch (Exception e) {
+            log.warn("게시글 이미지 GCS 삭제 실패 - url: {}, error: {}", url, e.getMessage());
+          }
+        });
 
     try {
       gcsService.delete(profileImageUrl);

--- a/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
+++ b/src/main/java/com/plog/plogbackend/domain/Member/service/MemberService.java
@@ -11,12 +11,26 @@ import com.plog.plogbackend.domain.Member.repository.MemberAgreementRepository;
 import com.plog.plogbackend.domain.Member.repository.MemberRepository;
 import com.plog.plogbackend.domain.Member.repository.TermsRepository;
 import com.plog.plogbackend.domain.badge.event.BadgeGrantEvent;
+import com.plog.plogbackend.domain.badge.repository.MemberBadgeRepository;
+import com.plog.plogbackend.domain.bookmark.repository.BookMarkRepository;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.entity.PostImage;
+import com.plog.plogbackend.domain.post.repository.LikeRepository;
+import com.plog.plogbackend.domain.post.repository.PostImageRepository;
+import com.plog.plogbackend.domain.post.repository.PostRepository;
+import com.plog.plogbackend.domain.post.repository.PostTagRepository;
+import com.plog.plogbackend.domain.post.repository.RecentPlaceSearchRepository;
 import com.plog.plogbackend.global.error.AppException;
 import com.plog.plogbackend.global.error.ErrorType;
+import com.plog.plogbackend.global.util.GcsService;
 import com.plog.plogbackend.security.jwt.JwtProvider;
+import com.plog.plogbackend.security.jwt.RefreshTokenRepository;
+import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,14 +47,11 @@ public class MemberService {
   private static final long BADGE_ID_FIRST_LOGIN = 1L;
 
   /** 유효성 검사 패턴. (메모리 낭비 방지) */
-  private static final Pattern PHONE_PATTERN =
-      Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
+  private static final Pattern PHONE_PATTERN = Pattern.compile("(?:010|02|0[3-9]{2})[-.\\s]?\\d{3,4}[-.\\s]?\\d{4}");
 
-  private static final Pattern EMAIL_PATTERN =
-      Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
-  private static final Pattern SNS_PATTERN =
-      Pattern.compile(
-          "kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
+  private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}");
+  private static final Pattern SNS_PATTERN = Pattern.compile(
+      "kakao|카카오|카톡|insta|인스타|facebook|페이스북|페북|twitter|트위터|telegram|텔레그램|line|라인|@[a-zA-Z0-9._]+");
 
   private final MemberRepository memberRepository;
   private final JwtProvider jwtProvider;
@@ -49,18 +60,31 @@ public class MemberService {
   private final MemberAgreementRepository memberAgreementRepository;
   private final BadWordFilterService badWordFilterService;
 
+  // Withdrawal required repositories
+  private final RecentPlaceSearchRepository recentPlaceSearchRepository;
+  private final LikeRepository likeRepository;
+  private final BookMarkRepository bookMarkRepository;
+  private final MemberBadgeRepository memberBadgeRepository;
+  private final PostImageRepository postImageRepository;
+  private final PostTagRepository postTagRepository;
+  private final PostRepository postRepository;
+  private final GcsService gcsService;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final EntityManager entityManager;
+
   // 이벤트 처리 객체
   private final ApplicationEventPublisher eventPublisher;
 
   /**
    * 회원가입을 처리합니다.
    *
-   * <p>프로필 이미지는 파일 업로드 또는 기본 이미지 URL 중 하나를 반드시 제공해야 합니다. 이미지 결정은 {@link
+   * <p>
+   * 프로필 이미지는 파일 업로드 또는 기본 이미지 URL 중 하나를 반드시 제공해야 합니다. 이미지 결정은 {@link
    * MemberImageService#resolveSignupProfileImage}에 위임합니다.
    *
-   * @param registerToken 카카오 인증 후 발급된 임시 가입 토큰
-   * @param request 닉네임, 약관동의 정보
-   * @param profileImage 직접 업로드할 이미지 파일 (nullable)
+   * @param registerToken  카카오 인증 후 발급된 임시 가입 토큰
+   * @param request        닉네임, 약관동의 정보
+   * @param profileImage   직접 업로드할 이미지 파일 (nullable)
    * @param defaultImageId 기본 이미지 ID (profileImage가 없을 때 사용, nullable)
    * @return 생성된 회원의 memberKey
    */
@@ -85,31 +109,27 @@ public class MemberService {
     validateIntroduction(request.introduction());
 
     // 파일 또는 기본 이미지 ID 중 하나는 반드시 있어야 함 (없으면 FILE_EMPTY 예외)
-    String profileImageUrl =
-        memberImageService.resolveSignupProfileImage(profileImage, defaultImageId);
+    String profileImageUrl = memberImageService.resolveSignupProfileImage(profileImage, defaultImageId);
 
-    Member member =
-        Member.createNewMember(
-            request.nickname(), providerId, profileImageUrl, request.introduction());
+    Member member = Member.createNewMember(
+        request.nickname(), providerId, profileImageUrl, request.introduction());
     memberRepository.save(member);
 
     if (request.termsAgreements() != null) {
       for (Map.Entry<String, Boolean> entry : request.termsAgreements().entrySet()) {
-        Terms terms =
-            termsRepository
-                .findByName(entry.getKey())
-                .orElseThrow(() -> new AppException(ErrorType.TERMS_NOT_FOUND));
+        Terms terms = termsRepository
+            .findByName(entry.getKey())
+            .orElseThrow(() -> new AppException(ErrorType.TERMS_NOT_FOUND));
 
         if (terms.isRequired() && !entry.getValue()) {
           throw new AppException(ErrorType.REQUIRED_TERMS_NOT_AGREED);
         }
 
-        MemberAgreement agreement =
-            MemberAgreement.builder()
-                .member(member)
-                .terms(terms)
-                .isAgreed(entry.getValue())
-                .build();
+        MemberAgreement agreement = MemberAgreement.builder()
+            .member(member)
+            .terms(terms)
+            .isAgreed(entry.getValue())
+            .build();
         memberAgreementRepository.save(agreement);
       }
     }
@@ -129,10 +149,9 @@ public class MemberService {
    */
   @Transactional(readOnly = true)
   public MemberResponse getMyPageInfo(UUID memberKey) {
-    Member member =
-        memberRepository
-            .findByMemberKey(memberKey)
-            .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+    Member member = memberRepository
+        .findByMemberKey(memberKey)
+        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
 
     MemberBadgeResponse badgeResponse = null;
     if (member.getMainBadge() != null) {
@@ -150,34 +169,35 @@ public class MemberService {
   /**
    * 프로필(닉네임 + 이미지)을 한 번에 수정합니다.
    *
-   * <p>이미지가 제공된 경우:
+   * <p>
+   * 이미지가 제공된 경우:
    *
    * <ul>
-   *   <li>파일이면 GCS에 업로드 후 URL 저장, 기존 커스텀 이미지는 커밋 후 GCS 삭제
-   *   <li>기본 이미지 ID이면 DB 검증 후 해당 URL로 교체
+   * <li>파일이면 GCS에 업로드 후 URL 저장, 기존 커스텀 이미지는 커밋 후 GCS 삭제
+   * <li>기본 이미지 ID이면 DB 검증 후 해당 URL로 교체
    * </ul>
    *
-   * <p>닉네임이 null 또는 빈 값이면 닉네임은 변경하지 않습니다.
+   * <p>
+   * 닉네임이 null 또는 빈 값이면 닉네임은 변경하지 않습니다.
    *
-   * <p>이미지가 null이고 defaultImageId도 null이면 이미지는 변경하지 않습니다.
+   * <p>
+   * 이미지가 null이고 defaultImageId도 null이면 이미지는 변경하지 않습니다.
    *
-   * @param memberKey 회원 UUID
-   * @param request 닉네임 변경 정보 (nullable 허용)
-   * @param file 업로드할 이미지 파일 (nullable)
+   * @param memberKey      회원 UUID
+   * @param request        닉네임 변경 정보 (nullable 허용)
+   * @param file           업로드할 이미지 파일 (nullable)
    * @param defaultImageId 기본 이미지 ID (file이 없을 때 사용, nullable)
    */
   @Transactional
   public void updateProfile(
       UUID memberKey, UpdateProfileRequest request, MultipartFile file, Long defaultImageId) {
 
-    Member member =
-        memberRepository
-            .findByMemberKey(memberKey)
-            .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+    Member member = memberRepository
+        .findByMemberKey(memberKey)
+        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
 
     // 이미지 변경 처리 (변경 없으면 null 반환)
-    String newImageUrl =
-        memberImageService.resolveAndScheduleImageUpdate(member, file, defaultImageId);
+    String newImageUrl = memberImageService.resolveAndScheduleImageUpdate(member, file, defaultImageId);
 
     String newNickname = request.nickname();
     String newIntroduction = request.introduction();
@@ -243,5 +263,90 @@ public class MemberService {
 
     // 금칙어 검사
     badWordFilterService.validate(introduction);
+  }
+
+  /**
+   * 회원 탈퇴 - 하드 딜리트
+   *
+   * <p>삭제 순서:
+   * 1) 리프레시 토큰 DB 삭제
+   * 2) 최근 장소 검색 기록 삭제
+   * 3) 회원이 누른 좋아요/북마크 삭제
+   * 4) 획득 배지·약관 동의 내역 삭제
+   * 5) 작성 게시글 하위 데이터 + GCS 파일 + 게시글 삭제
+   * 6) GCS 프로필 이미지 삭제
+   * 7) flush & clear → Member DB 삭제 (영속성 충돌 해소)
+   *
+   * <p>쿠키 초기화는 호출 측 컨트롤러에서 HttpServletResponse로 처리한다.
+   *
+   * @param memberKey 탈퇴할 회원 UUID
+   */
+  @Transactional
+  public void withdraw(UUID memberKey) {
+    Member member = memberRepository.findByMemberKey(memberKey)
+        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+
+    Long memberId = member.getId();
+    String profileImageUrl = member.getProfileImage(); // 프로필 삭제하기 전에 프로필 사진 수집
+
+    // 1. 리프레시 토큰 DB 삭제
+    refreshTokenRepository.deleteByMemberKey(memberKey);
+
+    // 2. 최근 장소 검색 기록 삭제
+    recentPlaceSearchRepository.deleteAllByMemberId(memberId);
+
+    // 3. 회원이 다른 게시글에 남긴 좋아요·북마크 삭제
+    likeRepository.deleteAllByMemberId(memberId);
+    bookMarkRepository.deleteAllByMemberId(memberId);
+
+    // 4. 획득 배지·약관 동의 내역 삭제
+    memberBadgeRepository.deleteAllByMemberId(memberId);
+    memberAgreementRepository.deleteAllByMemberId(memberId);
+
+    // 5. 작성 게시글 하위 데이터 + 게시글 DB 삭제
+    List<Post> myPosts = postRepository.findAllByMemberId(memberId);
+    List<String> postImageUrls = List.of(); // GCS 삭제용 URL 목록 (DB 삭제 전에 수집)
+    if (!myPosts.isEmpty()) {
+      List<Long> postIds = myPosts.stream().map(Post::getId).collect(Collectors.toList());
+
+      // GCS 삭제를 위해 URL만 미리 수집
+      postImageUrls = postImageRepository.findAllByPostIdIn(postIds)
+          .stream().map(PostImage::getImageUrl).collect(Collectors.toList());
+
+      // 하위 레코드 bulk JPQL delete
+      postImageRepository.deleteAllByPostIdIn(postIds);
+      postTagRepository.deleteAllByPostIdIn(postIds);
+      likeRepository.deleteAllByPostIdIn(postIds);   // 어떤 타 회원의 좋아요도 있을 수 있음
+      bookMarkRepository.deleteAllByPostIdIn(postIds); // 같은 이유
+
+      // 게시글 bulk delete
+      postRepository.deleteAllByIdIn(postIds);
+    }
+
+    // 6. @Modifying JPQL로 삭제한 내용을 flush로 DB에 확정하고,
+    //    clear로 1차 캐시(영속성 컨텍스트)를 비워 충돌을 제거
+    entityManager.flush();
+    entityManager.clear();
+
+    // clear 후 detached 상태이면 재조회한 뒤 삭제
+    memberRepository.findByMemberKey(memberKey).ifPresent(memberRepository::delete);
+
+    // 7. DB 삭제가 완전히 완료된 후 GCS 파일 삭제
+    final List<String> finalPostImageUrls = postImageUrls;
+    finalPostImageUrls.forEach(url -> {
+      try {
+        gcsService.delete(url);
+      } catch (Exception e) {
+        log.warn("게시글 이미지 GCS 삭제 실패 - url: {}, error: {}", url, e.getMessage());
+      }
+    });
+
+    try {
+      gcsService.delete(profileImageUrl);
+    } catch (Exception e) {
+      log.warn("프로필 이미지 GCS 삭제 실패 - url: {}, error: {}", profileImageUrl, e.getMessage());
+    }
+
+    log.info("회원 탈퇴 완료 (하드 딜리트) - memberKey: {}", memberKey);
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/badge/repository/MemberBadgeRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/badge/repository/MemberBadgeRepository.java
@@ -3,6 +3,8 @@ package com.plog.plogbackend.domain.badge.repository;
 import com.plog.plogbackend.domain.badge.entity.MemberBadge;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> {
 
@@ -11,4 +13,8 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
 
   /** 특정 회원의 모든 획득 뱃지 조회 */
   List<MemberBadge> findAllByMemberId(Long memberId);
+
+  @Modifying
+  @Query("DELETE FROM MemberBadge mb WHERE mb.member.id = :memberId")
+  void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/plog/plogbackend/domain/bookmark/repository/BookMarkRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/bookmark/repository/BookMarkRepository.java
@@ -1,8 +1,11 @@
 package com.plog.plogbackend.domain.bookmark.repository;
 
 import com.plog.plogbackend.domain.bookmark.entity.BookMark;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
 
@@ -12,4 +15,12 @@ public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
 
   /** 특정 회원의 전체 북마크 수 조회 (첫 북마크 뱃지 부여 조건 판단용) */
   long countByMemberId(Long memberId);
+
+  @Modifying
+  @Query("DELETE FROM BookMark b WHERE b.member.id = :memberId")
+  void deleteAllByMemberId(Long memberId);
+
+  @Modifying
+  @Query("DELETE FROM BookMark b WHERE b.post.id IN :postIds")
+  void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/repository/LikeRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/repository/LikeRepository.java
@@ -1,12 +1,23 @@
 package com.plog.plogbackend.domain.post.repository;
 
 import com.plog.plogbackend.domain.post.entity.Like;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
   Optional<Like> findByPostIdAndMemberId(Long postId, Long memberId);
 
   Boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
+  @Modifying
+  @Query("DELETE FROM Like l WHERE l.member.id = :memberId")
+  void deleteAllByMemberId(Long memberId);
+
+  @Modifying
+  @Query("DELETE FROM Like l WHERE l.post.id IN :postIds")
+  void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/repository/PostImageRepository.java
@@ -3,6 +3,8 @@ package com.plog.plogbackend.domain.post.repository;
 import com.plog.plogbackend.domain.post.entity.PostImage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
@@ -11,4 +13,10 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
   int countByPostId(Long postId); // 게시글 이미지 개수 조회
 
   void deleteAllByPostId(Long postId); // 게시글 모든 이미지 삭제
+
+  List<PostImage> findAllByPostIdIn(List<Long> postIds);
+
+  @Modifying
+  @Query("DELETE FROM PostImage pi WHERE pi.post.id IN :postIds")
+  void deleteAllByPostIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.plog.plogbackend.domain.post.repository;
 
 import com.plog.plogbackend.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,10 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
   /** 특정 회원의 전체 게시글 수 조회 (첫 게시글 뱃지 부여 조건 판단용) */
   long countByMemberId(Long memberId);
+
+  List<Post> findAllByMemberId(Long memberId);
+
+  @Modifying
+  @Query("DELETE FROM Post p WHERE p.id IN :postIds")
+  void deleteAllByIdIn(List<Long> postIds);
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/repository/PostTagRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/repository/PostTagRepository.java
@@ -1,6 +1,14 @@
 package com.plog.plogbackend.domain.post.repository;
 
 import com.plog.plogbackend.domain.post.entity.PostTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface PostTagRepository extends JpaRepository<PostTag, Long> {}
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+
+  @Modifying
+  @Query("DELETE FROM PostTag pt WHERE pt.post.id IN :postIds")
+  void deleteAllByPostIdIn(List<Long> postIds);
+}

--- a/src/main/java/com/plog/plogbackend/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/plog/plogbackend/security/oauth2/OAuth2SuccessHandler.java
@@ -62,8 +62,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
       // 프론트엔드의 메인 페이지(또는 로그인 성공 처리 페이지)로 리다이렉트
-            String redirectUrl = frontendUrl + "/success.html"; // 로컬 HTML 테스트 전용 경로
-//      String redirectUrl = frontendUrl + "/map";
+      //            String redirectUrl = frontendUrl + "/success.html"; // 로컬 HTML 테스트 전용 경로
+      String redirectUrl = frontendUrl + "/map";
       getRedirectStrategy().sendRedirect(request, response, redirectUrl);
 
     } else {
@@ -79,8 +79,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE, cookie2.toString());
 
       // 프론트엔드 추가 정보 입력(회원가입) 페이지로 리다이렉트
-            String redirectUrl = frontendUrl + "/signup.html"; // 로컬 HTML 테스트 전용 경로
-//      String redirectUrl = frontendUrl + "/signup";
+      //            String redirectUrl = frontendUrl + "/signup.html"; // 로컬 HTML 테스트 전용 경로
+      String redirectUrl = frontendUrl + "/signup";
       getRedirectStrategy().sendRedirect(request, response, redirectUrl); // 리다이렉트
     }
   }

--- a/src/main/java/com/plog/plogbackend/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/plog/plogbackend/security/oauth2/OAuth2SuccessHandler.java
@@ -62,8 +62,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
       // 프론트엔드의 메인 페이지(또는 로그인 성공 처리 페이지)로 리다이렉트
-      //      String redirectUrl = frontendUrl + "/success.html"; // 로컬 HTML 테스트 전용 경로
-      String redirectUrl = frontendUrl + "/map";
+            String redirectUrl = frontendUrl + "/success.html"; // 로컬 HTML 테스트 전용 경로
+//      String redirectUrl = frontendUrl + "/map";
       getRedirectStrategy().sendRedirect(request, response, redirectUrl);
 
     } else {
@@ -79,8 +79,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE, cookie2.toString());
 
       // 프론트엔드 추가 정보 입력(회원가입) 페이지로 리다이렉트
-      //      String redirectUrl = frontendUrl + "/signup.html"; // 로컬 HTML 테스트 전용 경로
-      String redirectUrl = frontendUrl + "/signup";
+            String redirectUrl = frontendUrl + "/signup.html"; // 로컬 HTML 테스트 전용 경로
+//      String redirectUrl = frontendUrl + "/signup";
       getRedirectStrategy().sendRedirect(request, response, redirectUrl); // 리다이렉트
     }
   }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 10MB
-      max-request-size: 50MB
+      max-request-size: 60MB
 
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
   servlet:
     multipart:
       max-file-size: 10MB
-      max-request-size: 50MB
+      max-request-size: 60MB
 
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/static/success.html
+++ b/src/main/resources/static/success.html
@@ -631,6 +631,20 @@
       </div>
     </div>
 
+    <!-- 회원 탈퇴 테스트 -->
+    <div class="card">
+      <div class="card-title">⚠️ 회원 탈퇴 테스트</div>
+      <div>
+        <p style="font-size: 0.85rem; color: #fca5a5; margin-bottom: 12px; line-height: 1.6;">
+          <strong>주의:</strong> 회원 탈퇴 시 작성한 게시글, 뱃지, 북마크 및 GCS 이미지 등 모든 데이터가 즉시 삭제(하드 딜리트)됩니다.
+        </p>
+        <button class="api-run-btn" onclick="withdrawMember()" style="width: 100%; padding: 12px; font-weight: 600; background: rgba(239, 68, 68, 0.15); color: #fca5a5; border-color: rgba(239, 68, 68, 0.3);">
+          회원 탈퇴 실행 (DELETE)
+        </button>
+        <div class="api-result" id="result-withdraw"></div>
+      </div>
+    </div>
+
     <!-- 하단 버튼 -->
     <div class="footer-btns" style="flex-wrap: wrap;">
       <a class="btn-outline" href="index.html">← 처음으로</a>
@@ -933,6 +947,35 @@
       const form = new FormData();
       Array.from(fileInput.files).forEach(file => form.append('images', file));
       doImageFetch('/api/test/images/upload', 'POST', form, 'result-post-img');
+    }
+
+    // ── 회원 탈퇴 로직 ──
+    async function withdrawMember() {
+      if(!confirm('정말 회원 탈퇴를 진행하시겠습니까?\n이 작업은 되돌릴 수 없으며 등록한 모든 데이터 및 사진이 영구히 삭제됩니다.')) return;
+      
+      const resultEl = document.getElementById('result-withdraw');
+      resultEl.style.display = 'block';
+      resultEl.style.color = '#fca5a5';
+      resultEl.textContent = '탈퇴 처리 중... (사진 등 데이터가 많을 경우 시간이 소요될 수 있습니다)';
+      
+      try {
+        const res = await fetch(`${API_BASE}/api/members/me`, { 
+          method: 'DELETE',
+          credentials: 'include' 
+        });
+        const json = await res.json();
+        
+        resultEl.style.color = res.ok ? '#86efac' : '#fca5a5';
+        resultEl.textContent = `HTTP ${res.status}\n${JSON.stringify(json, null, 2)}`;
+        
+        if (res.ok) {
+          alert('회원 탈퇴가 성공적으로 완료되었습니다. 로그인 화면으로 이동합니다.');
+          window.location.href = 'index.html';
+        }
+      } catch (err) {
+        resultEl.style.color = '#fca5a5';
+        resultEl.textContent = `연결 실패: ${err.message}`;
+      }
     }
 
   </script>


### PR DESCRIPTION
회원 탈퇴시 해당 회원의 모든 정보와 게시글, gcp 이미지를 삭제합니다

nginx 의 client_max_body_size 60M; 를 추가하여, 10mb 이미지 5개 + 요청 헤더+페이로드 모두 받을수 있도록 넉넉히 했습니다.

다른 도메인의 리포지토리에 delete 매서드들을 추가했습니다.