### PR TITLE
feature/Post 엔티티 메소드 추가 

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/post/controller/PostController.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/PostController.java
@@ -4,8 +4,10 @@ import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
 import com.plog.plogbackend.domain.post.controller.api.PostMapper;
 import com.plog.plogbackend.domain.post.controller.dto.request.post.PostCreateRequest;
 import com.plog.plogbackend.domain.post.controller.dto.response.PostCreateResponse;
+import com.plog.plogbackend.domain.post.controller.dto.response.PostQueryResponse;
 import com.plog.plogbackend.domain.post.controller.dto.response.PostTextResponse;
 import com.plog.plogbackend.domain.post.service.PostImageService;
+import com.plog.plogbackend.domain.post.service.PostQueryService;
 import com.plog.plogbackend.domain.post.service.PostService;
 import com.plog.plogbackend.domain.post.service.dto.PostCreateCommand;
 import com.plog.plogbackend.global.response.ApiResponse;
@@ -19,10 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "게시글", description = "게시글 관련 API")
@@ -33,6 +32,7 @@ public class PostController {
 
   private final PostImageService postImageService;
   private final PostService postService;
+  private final PostQueryService postQueryService;
 
   @Operation(summary = "게시글 생성", description = "게시글 정보와 이미지를 함께 업로드합니다. (이미지 최대 5개)")
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -54,5 +54,12 @@ public class PostController {
 
     return ResponseEntity.ok(
         ApiResponse.success(PostCreateResponse.of(postTextResponse, imageResponse)));
+  }
+
+  @GetMapping("/{postId}/edit")
+  public ResponseEntity<ApiResponse<PostQueryResponse>> getPost(
+      @PathVariable Long postId, @AuthenticationPrincipal UUID memberKey) {
+    PostQueryResponse post = postQueryService.getPost(postId, memberKey);
+    return ResponseEntity.ok(ApiResponse.success(post));
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/PostController.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.plog.plogbackend.domain.post.controller;
 import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
 import com.plog.plogbackend.domain.post.controller.api.PostMapper;
 import com.plog.plogbackend.domain.post.controller.dto.request.post.PostCreateRequest;
+import com.plog.plogbackend.domain.post.controller.dto.request.post.PostUpdateRequest;
 import com.plog.plogbackend.domain.post.controller.dto.response.PostCreateResponse;
 import com.plog.plogbackend.domain.post.controller.dto.response.PostQueryResponse;
 import com.plog.plogbackend.domain.post.controller.dto.response.PostTextResponse;
@@ -10,6 +11,7 @@ import com.plog.plogbackend.domain.post.service.PostImageService;
 import com.plog.plogbackend.domain.post.service.PostQueryService;
 import com.plog.plogbackend.domain.post.service.PostService;
 import com.plog.plogbackend.domain.post.service.dto.PostCreateCommand;
+import com.plog.plogbackend.domain.post.service.dto.PostUpdateCommand;
 import com.plog.plogbackend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -56,10 +58,46 @@ public class PostController {
         ApiResponse.success(PostCreateResponse.of(postTextResponse, imageResponse)));
   }
 
+  @Operation(summary = "수정용 게시글 조회", description = "본인 게시글의 수정 폼에 표시할 데이터를 조회합니다.")
   @GetMapping("/{postId}/edit")
   public ResponseEntity<ApiResponse<PostQueryResponse>> getPost(
-      @PathVariable Long postId, @AuthenticationPrincipal UUID memberKey) {
+      @PathVariable Long postId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
     PostQueryResponse post = postQueryService.getPost(postId, memberKey);
     return ResponseEntity.ok(ApiResponse.success(post));
+  }
+
+  @Operation(
+      summary = "게시글 수정",
+      description =
+          "본인 게시글을 수정합니다. keepImageIds로 유지할 기존 이미지를 지정하고, " + "images로 새 이미지를 업로드합니다. (총합 5개 이하)")
+  @PutMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ApiResponse<PostQueryResponse>> updatePost(
+      @PathVariable Long postId,
+      @Parameter(description = "게시글 수정 데이터") @Valid @RequestPart("request")
+          PostUpdateRequest request,
+      @Parameter(description = "새로 추가된 이미지 (옵션)") @RequestPart(value = "images", required = false)
+          List<MultipartFile> images,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+
+    PostUpdateCommand command = PostMapper.from(postId, request, memberKey);
+
+    postService.update(command);
+    postImageService.replacePostImages(postId, request.keepImageIds(), images);
+
+    PostQueryResponse response = postQueryService.getPost(postId, memberKey);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "게시글 삭제", description = "본인 게시글을 삭제합니다.")
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<ApiResponse<Void>> deletePost(
+      @PathVariable Long postId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+
+    postService.delete(postId, memberKey);
+    postImageService.deleteAllPostImages(postId);
+
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/api/PostMapper.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/api/PostMapper.java
@@ -2,6 +2,7 @@ package com.plog.plogbackend.domain.post.controller.api;
 
 import com.plog.plogbackend.domain.post.controller.dto.request.FeedFindRequest;
 import com.plog.plogbackend.domain.post.controller.dto.request.post.PostCreateRequest;
+import com.plog.plogbackend.domain.post.controller.dto.request.post.PostUpdateRequest;
 import com.plog.plogbackend.domain.post.service.dto.*;
 import java.util.UUID;
 
@@ -35,5 +36,22 @@ public class PostMapper {
         request.placeTags(),
         request.categoryCode(),
         memberKey);
+  }
+
+  public static PostUpdateCommand from(Long postId, PostUpdateRequest request, UUID memberKey) {
+    return new PostUpdateCommand(
+        postId,
+        memberKey,
+        request.title(),
+        request.contents(),
+        TimePickerCommand.from(request.startedAt()),
+        TimePickerCommand.from(request.endedAt()),
+        request.studyDate(),
+        request.focus(),
+        request.scope(),
+        PlaceCommand.from(request.place()),
+        request.placeTags(),
+        request.categoryCode(),
+        request.keepImageIds());
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/PostUpdateRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/request/post/PostUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.plog.plogbackend.domain.post.controller.dto.request.post;
+
+import com.plog.plogbackend.domain.post.entity.PublicScope;
+import com.plog.plogbackend.domain.post.enums.PlaceCategoryCode;
+import com.plog.plogbackend.domain.tag.enums.PlaceTag;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record PostUpdateRequest(
+    @Schema(description = "제목") @NotBlank(message = "제목은 필수입니다.") String title,
+    @Schema(description = "내용") @NotBlank(message = "내용은 필수입니다.") String contents,
+    @Schema(description = "공부 시작 시각") @NotNull @Valid TimePickerRequest startedAt,
+    @Schema(description = "공부 종료 시각") @NotNull @Valid TimePickerRequest endedAt,
+    @Schema(description = "공부 날짜") @NotNull @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate studyDate,
+    @Min(value = 1, message = "집중도 최소값은 1입니다.")
+        @Max(value = 5, message = "집중도 최대값은 5입니다.")
+        @Schema(description = "집중도")
+        @NotNull
+        Integer focus,
+    @Schema(description = "공개 범위") @NotNull PublicScope scope,
+    @Schema(description = "장소 정보") @NotNull @Valid PlaceRequest place,
+    @Schema(description = "장소 태그", example = "[\"WIFI_FAST\", \"GOOD_VIBE\"]") @NotEmpty
+        List<PlaceTag> placeTags,
+    @Schema(description = "장소 카테고리", example = "STUDY_CAFE") @NotNull
+        PlaceCategoryCode categoryCode,
+    @Schema(description = "유지할 기존 이미지 ID 목록 (없으면 빈 배열)") @NotNull List<Long> keepImageIds) {}

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostImageResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostImageResponse.java
@@ -1,0 +1,18 @@
+package com.plog.plogbackend.domain.post.controller.dto.response;
+
+import com.plog.plogbackend.domain.post.entity.PostImage;
+import java.util.List;
+
+public record PostImageResponse(List<PostImageItem> images, int total) {
+
+  public static PostImageResponse from(List<PostImage> postImages) {
+    List<PostImageItem> items = postImages.stream().map(PostImageItem::from).toList();
+    return new PostImageResponse(items, items.size());
+  }
+
+  public record PostImageItem(Long id, String url) {
+    public static PostImageItem from(PostImage postImage) {
+      return new PostImageItem(postImage.getId(), postImage.getImageUrl());
+    }
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostQueryResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostQueryResponse.java
@@ -1,0 +1,7 @@
+package com.plog.plogbackend.domain.post.controller.dto.response;
+
+public record PostQueryResponse(PostRequestPartResponse request, PostImageResponse images) {
+  public static PostQueryResponse of(PostRequestPartResponse request, PostImageResponse images) {
+    return new PostQueryResponse(request, images);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostQueryResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostQueryResponse.java
@@ -1,7 +1,7 @@
 package com.plog.plogbackend.domain.post.controller.dto.response;
 
-public record PostQueryResponse(PostRequestPartResponse request, PostImageResponse images) {
-  public static PostQueryResponse of(PostRequestPartResponse request, PostImageResponse images) {
-    return new PostQueryResponse(request, images);
+public record PostQueryResponse(PostRequestPartResponse post, PostImageResponse images) {
+  public static PostQueryResponse of(PostRequestPartResponse post, PostImageResponse images) {
+    return new PostQueryResponse(post, images);
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostRequestPartResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/PostRequestPartResponse.java
@@ -1,0 +1,43 @@
+package com.plog.plogbackend.domain.post.controller.dto.response;
+
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.entity.PublicScope;
+import com.plog.plogbackend.domain.post.enums.PlaceCategoryCode;
+import com.plog.plogbackend.domain.tag.enums.PlaceTag;
+import java.time.LocalDate;
+import java.util.List;
+
+public record PostRequestPartResponse(
+    String title,
+    String contents,
+    TimePickerResponse startedAt,
+    TimePickerResponse endedAt,
+    LocalDate studyDate,
+    Integer studyTime,
+    Integer focus,
+    PublicScope scope,
+    List<PlaceTag> placeTags,
+    String placeName,
+    String placeAddress,
+    Double latitude,
+    Double longitude,
+    PlaceCategoryCode categoryCode) {
+
+  public static PostRequestPartResponse from(Post post) {
+    return new PostRequestPartResponse(
+        post.getTitle(),
+        post.getContents(),
+        TimePickerResponse.from(post.getStartedAt()),
+        TimePickerResponse.from(post.getEndedAt()),
+        post.getStudyDate(),
+        post.getStudyTime(),
+        post.getFocus(),
+        post.getScope(),
+        post.getTags().stream().map(postTag -> postTag.getTag().getPlaceTag()).toList(),
+        post.getPlace().getName(),
+        post.getPlace().getAddress(),
+        post.getPlace().getLatitude(),
+        post.getPlace().getLongitude(),
+        post.getPlaceCategory().getCategoryName());
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/TimePickerResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/TimePickerResponse.java
@@ -1,0 +1,17 @@
+package com.plog.plogbackend.domain.post.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(
+    name = "TimePickerResponse",
+    description = "타임피커 응답 — hour/minute 분리",
+    example = "{\"hour\": 14, \"minute\": 30}")
+public record TimePickerResponse(
+    @Schema(description = "시 (0~23)", example = "14") Integer hour,
+    @Schema(description = "분 (0~59)", example = "30") Integer minute) {
+
+  public static TimePickerResponse from(LocalDateTime localDateTime) {
+    return new TimePickerResponse(localDateTime.getHour(), localDateTime.getMinute());
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/entity/Post.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/entity/Post.java
@@ -119,6 +119,28 @@ public class Post extends BaseTimeStatusEntity {
         .build();
   }
 
+  public void update(
+      String title,
+      String contents,
+      LocalDateTime startedAt,
+      LocalDateTime endedAt,
+      LocalDate studyDate,
+      Integer focus,
+      PublicScope scope,
+      Place place,
+      PlaceCategory placeCategory) {
+    this.title = title;
+    this.contents = contents;
+    this.startedAt = startedAt;
+    this.endedAt = endedAt;
+    this.studyTime = Math.toIntExact(Duration.between(startedAt, endedAt).toMinutes());
+    this.studyDate = studyDate;
+    this.focus = focus;
+    this.scope = scope;
+    this.place = place;
+    this.placeCategory = placeCategory;
+  }
+
   // 게시글 수정 시 편의 메소드
   public void updateTime(LocalDateTime newStartedAt, LocalDateTime newEndedAt) {
     this.startedAt = newStartedAt;

--- a/src/main/java/com/plog/plogbackend/domain/post/repository/PostTagRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/repository/PostTagRepository.java
@@ -3,4 +3,6 @@ package com.plog.plogbackend.domain.post.repository;
 import com.plog.plogbackend.domain.post.entity.PostTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostTagRepository extends JpaRepository<PostTag, Long> {}
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+  void deleteAllByPostId(Long postId);
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/service/PostImageService.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/service/PostImageService.java
@@ -8,7 +8,10 @@ import com.plog.plogbackend.domain.post.repository.PostRepository;
 import com.plog.plogbackend.global.error.AppException;
 import com.plog.plogbackend.global.error.ErrorType;
 import com.plog.plogbackend.global.util.GcsService;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -134,5 +137,60 @@ public class PostImageService {
     return files.stream()
         .map(file -> new ImageUrlResponse(gcsService.upload(file, "test")))
         .toList();
+  }
+
+  /**
+   * 게시글 이미지를 keep + new 조합으로 일괄 교체합니다.
+   *
+   * @param postId 게시글 ID
+   * @param keepImageIds 유지할 기존 이미지 ID
+   * @param newFiles 새로 업로드할 파일 (없으면 빈 리스트/null 허용)
+   */
+  @Transactional
+  public void replacePostImages(
+      Long postId, List<Long> keepImageIds, List<MultipartFile> newFiles) {
+
+    Post post =
+        postRepository
+            .findById(postId)
+            .orElseThrow(() -> new AppException(ErrorType.POST_NOT_FOUND));
+
+    List<Long> safeKeepIds = keepImageIds == null ? List.of() : keepImageIds;
+    List<MultipartFile> safeNew =
+        newFiles == null
+            ? List.of()
+            : newFiles.stream().filter(f -> f != null && !f.isEmpty()).toList();
+
+    if (safeKeepIds.size() + safeNew.size() > POST_IMAGE_MAX) {
+      throw new AppException(ErrorType.POST_IMAGE_LIMIT_EXCEEDED);
+    }
+
+    List<PostImage> current = postImageRepository.findAllByPostId(postId);
+    Set<Long> currentIds = current.stream().map(PostImage::getId).collect(Collectors.toSet());
+
+    // keepImageIds 위변조 방지: 본 게시글의 이미지가 아닌 ID가 섞이면 거부
+    if (!currentIds.containsAll(safeKeepIds)) {
+      throw new AppException(ErrorType.INVALID_ACCESS_PATH);
+    }
+
+    Set<Long> keepSet = new HashSet<>(safeKeepIds);
+    List<PostImage> toDelete =
+        current.stream().filter(img -> !keepSet.contains(img.getId())).toList();
+
+    toDelete.forEach(img -> gcsService.delete(img.getImageUrl()));
+    postImageRepository.deleteAll(toDelete);
+
+    safeNew.forEach(
+        file -> {
+          String url = gcsService.upload(file, POST_DIR);
+          postImageRepository.save(PostImage.of(url, post));
+        });
+
+    log.debug(
+        "게시글 이미지 교체 완료 - postId: {}, kept: {}, deleted: {}, added: {}",
+        postId,
+        safeKeepIds.size(),
+        toDelete.size(),
+        safeNew.size());
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/service/PostQueryService.java
@@ -1,0 +1,39 @@
+package com.plog.plogbackend.domain.post.service;
+
+import com.plog.plogbackend.domain.post.controller.dto.response.PostImageResponse;
+import com.plog.plogbackend.domain.post.controller.dto.response.PostQueryResponse;
+import com.plog.plogbackend.domain.post.controller.dto.response.PostRequestPartResponse;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.repository.PostRepository;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostQueryService {
+
+  private final PostRepository postRepository;
+
+  public PostQueryResponse getPost(Long postId, UUID memberKey) {
+
+    Post post =
+        postRepository
+            .findById(postId)
+            .orElseThrow(() -> new AppException(ErrorType.POST_NOT_FOUND));
+
+    // 작성자 본인만 수정용 조회 가능
+    if (!post.getMember().getMemberKey().equals(memberKey)) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+
+    PostRequestPartResponse postResponse = PostRequestPartResponse.from(post);
+    PostImageResponse postImageResponse = PostImageResponse.from(post.getImages());
+
+    return PostQueryResponse.of(postResponse, postImageResponse);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/post/service/PostService.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/service/PostService.java
@@ -9,19 +9,24 @@ import com.plog.plogbackend.domain.post.controller.dto.response.PostTextResponse
 import com.plog.plogbackend.domain.post.entity.PlaceCategory;
 import com.plog.plogbackend.domain.post.entity.Post;
 import com.plog.plogbackend.domain.post.entity.PostTag;
+import com.plog.plogbackend.domain.post.enums.PlaceCategoryCode;
 import com.plog.plogbackend.domain.post.repository.PlaceCategoryRepository;
 import com.plog.plogbackend.domain.post.repository.PostRepository;
 import com.plog.plogbackend.domain.post.repository.PostTagRepository;
 import com.plog.plogbackend.domain.post.service.dto.PlaceCommand;
 import com.plog.plogbackend.domain.post.service.dto.PostCreateCommand;
+import com.plog.plogbackend.domain.post.service.dto.PostUpdateCommand;
+import com.plog.plogbackend.domain.post.service.dto.TimePickerCommand;
 import com.plog.plogbackend.domain.tag.Tag;
 import com.plog.plogbackend.domain.tag.enums.PlaceTag;
 import com.plog.plogbackend.domain.tag.repository.TagRepository;
 import com.plog.plogbackend.global.error.AppException;
 import com.plog.plogbackend.global.error.ErrorType;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -32,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PostService {
+
   /** 첫 게시글 작성 뱃지 ID */
   private static final long BADGE_ID_FIRST_POST = 2L;
 
@@ -50,27 +56,22 @@ public class PostService {
 
   @Transactional
   public PostTextResponse create(PostCreateCommand command) {
+    validateTitleAndContent(command.title(), command.contents());
+    StudyTimeRange time =
+        resolveStudyTime(command.startedAt(), command.endedAt(), command.studyDate());
 
-    validateTitleAndContext(command);
+    Member member = findMember(command.memberKey());
+    PlaceCategory placeCategory = findPlaceCategory(command.categoryCode());
+    List<Tag> findTags = validateAndFindTags(command.placeTags());
+    Place place = findOrCreatePlace(command.place());
 
-    LocalDateTime startedAt = mapStartedAt(command);
-    LocalDateTime endedAt = mapEndedAt(command, startedAt);
-    validateStudyDuration(startedAt, endedAt);
-
-    Member member = findMember(command);
-    PlaceCategory placeCategory = findPlaceCategory(command);
-    List<Tag> findTags = validateAndFindTags(command);
-
-    Place place = findOrCreatePlace(command);
-
-    // Post 생성 및 저장 로직
     Post savedPost =
         postRepository.save(
             Post.of(
                 command.title(),
                 command.contents(),
-                startedAt,
-                endedAt,
+                time.startedAt(),
+                time.endedAt(),
                 command.studyDate(),
                 command.focus(),
                 command.scope(),
@@ -81,8 +82,6 @@ public class PostService {
     List<PostTag> postTags = findTags.stream().map(tag -> PostTag.of(savedPost, tag)).toList();
     postTagRepository.saveAll(postTags);
 
-    // 첫 게시글 뱃지(id:2) 부여 이벤트 발행
-    // - 트랜잭션 커밋 후 BadgeEventHandler가 독립 트랜잭션으로 처리
     long totalPosts = postRepository.countByMemberId(member.getId());
     if (totalPosts == 1) {
       eventPublisher.publishEvent(new BadgeGrantEvent(member.getId(), BADGE_ID_FIRST_POST));
@@ -91,95 +90,136 @@ public class PostService {
     return PostTextResponse.from(savedPost);
   }
 
-  private Place findOrCreatePlace(PostCreateCommand command) {
-    PlaceCommand placeReq = command.place();
+  @Transactional
+  public void update(PostUpdateCommand command) {
+    Post post =
+        postRepository
+            .findById(command.postId())
+            .orElseThrow(() -> new AppException(ErrorType.POST_NOT_FOUND));
+    if (!post.getMember().getMemberKey().equals(command.memberKey())) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+
+    validateTitleAndContent(command.title(), command.contents());
+    StudyTimeRange time =
+        resolveStudyTime(command.startedAt(), command.endedAt(), command.studyDate());
+
+    PlaceCategory placeCategory = findPlaceCategory(command.categoryCode());
+    Place place = findOrCreatePlace(command.place());
+    List<Tag> newTagEntities = validateAndFindTags(command.placeTags());
+
+    post.update(
+        command.title(),
+        command.contents(),
+        time.startedAt(),
+        time.endedAt(),
+        command.studyDate(),
+        command.focus(),
+        command.scope(),
+        place,
+        placeCategory);
+
+    postTagRepository.deleteAllByPostId(post.getId());
+    postTagRepository.flush();
+    List<PostTag> newPostTagLinks =
+        newTagEntities.stream().map(tag -> PostTag.of(post, tag)).toList();
+    postTagRepository.saveAll(newPostTagLinks);
+
+    // 양방향 컬렉션 동기화
+    post.getTags().clear();
+    post.getTags().addAll(newPostTagLinks);
+  }
+
+  @Transactional
+  public void delete(Long postId, UUID memberKey) {
+    Post post =
+        postRepository
+            .findById(postId)
+            .orElseThrow(() -> new AppException(ErrorType.POST_NOT_FOUND));
+
+    if (!post.getMember().getMemberKey().equals(memberKey)) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+
+    postTagRepository.deleteAllByPostId(post.getId());
+
+    postRepository.delete(post);
+  }
+
+  private Member findMember(UUID memberKey) {
+    return memberRepository
+        .findByMemberKey(memberKey)
+        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+  }
+
+  private PlaceCategory findPlaceCategory(PlaceCategoryCode code) {
+    return placeCategoryRepository
+        .findByCategoryName(code)
+        .orElseThrow(() -> new AppException(ErrorType.CATEGORY_NOT_FOUND));
+  }
+
+  private Place findOrCreatePlace(PlaceCommand placeCmd) {
     return placeRepository
-        .findByNameAndAddress(placeReq.name(), placeReq.address())
+        .findByNameAndAddress(placeCmd.name(), placeCmd.address())
         .orElseGet(
             () ->
                 placeRepository.save(
                     Place.of(
-                        placeReq.name(),
-                        placeReq.address(),
-                        placeReq.latitude(),
-                        placeReq.longitude())));
+                        placeCmd.name(),
+                        placeCmd.address(),
+                        placeCmd.latitude(),
+                        placeCmd.longitude())));
   }
 
-  private PlaceCategory findPlaceCategory(PostCreateCommand command) {
-    return placeCategoryRepository
-        .findByCategoryName(command.categoryCode())
-        .orElseThrow(() -> new AppException(ErrorType.CATEGORY_NOT_FOUND));
-  }
-
-  private Member findMember(PostCreateCommand command) {
-    return memberRepository
-        .findByMemberKey(command.memberKey())
-        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
-  }
-
-  private static void validateTitleAndContext(PostCreateCommand command) {
-    // title text 입력
-    int titleLength = command.title().trim().length();
-    if (titleLength < 2 || titleLength > 20) {
-      throw new AppException(ErrorType.INVALID_TITLE_LENGTH);
-    }
-
-    // contents는 텍스트 + 이모티콘 혼합 허용
-    // codePointCount 함수는 이모티콘까지 한자리수로 인정하여 계산해준다
-    String trimmedContents = command.contents().trim();
-    int contentsCount = trimmedContents.codePointCount(0, trimmedContents.length());
-    if (contentsCount < 20 || contentsCount > 200) {
-      throw new AppException(ErrorType.INVALID_CONTENTS_LENGTH);
-    }
-  }
-
-  private List<Tag> validateAndFindTags(PostCreateCommand command) {
-    // 테그 입력값 검증필터
-    // 테그는 5개를 초과할 수 없다
-    List<PlaceTag> placeTags = command.placeTags().stream().distinct().toList();
-
+  private List<Tag> validateAndFindTags(List<PlaceTag> placeTagList) {
+    List<PlaceTag> placeTags = placeTagList.stream().distinct().toList();
     if (placeTags.size() > 5) {
       throw new AppException(ErrorType.TAG_LIMIT_EXCEEDED);
     }
-
-    // 검색 로직
     List<Tag> findTags = tagRepository.findByPlaceTagIn(placeTags);
-
-    // 전송된 데이터와 DB에 있는 테그 데이터가 정확한지 size로 검증한다
     if (placeTags.size() != findTags.size()) {
       throw new AppException(ErrorType.TAG_NOT_FOUND);
     }
     return findTags;
   }
 
-  private LocalDateTime mapStartedAt(PostCreateCommand command) {
-    return command.startedAt().atDate(command.studyDate());
+  private static void validateTitleAndContent(String title, String contents) {
+    int titleLength = title.trim().length();
+    if (titleLength < 2 || titleLength > 20) {
+      throw new AppException(ErrorType.INVALID_TITLE_LENGTH);
+    }
+    String trimmedContents = contents.trim();
+    int contentsCount = trimmedContents.codePointCount(0, trimmedContents.length());
+    if (contentsCount < 20 || contentsCount > 200) {
+      throw new AppException(ErrorType.INVALID_CONTENTS_LENGTH);
+    }
   }
 
-  /** 자정이 넘으면 자동으로 +1일 증가한다 */
-  private LocalDateTime mapEndedAt(PostCreateCommand command, LocalDateTime startedAt) {
-    LocalDateTime ended = command.endedAt().atDate(command.studyDate());
+  private StudyTimeRange resolveStudyTime(
+      TimePickerCommand startedAt, TimePickerCommand endedAt, LocalDate studyDate) {
+    LocalDateTime start = startedAt.atDate(studyDate);
+    LocalDateTime end = adjustEndedAt(start, endedAt.atDate(studyDate));
+    validateStudyDuration(start, end);
+    return new StudyTimeRange(start, end);
+  }
 
+  private static LocalDateTime adjustEndedAt(LocalDateTime startedAt, LocalDateTime ended) {
     if (ended.isAfter(startedAt)) {
-      return ended; // 정상 케이스
+      return ended;
     }
-
-    // 종료 <= 시작인 경우, 자정 넘김인지 오타인지 판단
     Duration backwardGap = Duration.between(ended, startedAt);
-
     if (backwardGap.toHours() >= ACTIVITY_DAY_CUTOFF_HOURS) {
-      // 오타로 판단 — 거부
       throw new AppException(ErrorType.INVALID_STUDY_TIME_RANGE);
     }
-
-    // 자정 넘김으로 판단 — 보정
     return ended.plusDays(1);
   }
 
-  private void validateStudyDuration(LocalDateTime startedAt, LocalDateTime endedAt) {
+  private static void validateStudyDuration(LocalDateTime startedAt, LocalDateTime endedAt) {
     long minutes = Duration.between(startedAt, endedAt).toMinutes();
     if (minutes > MAX_STUDY_MINUTES) {
       throw new AppException(ErrorType.STUDY_TIME_TOO_LONG);
     }
   }
+
+  private record StudyTimeRange(LocalDateTime startedAt, LocalDateTime endedAt) {}
 }

--- a/src/main/java/com/plog/plogbackend/domain/post/service/PostService.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/service/PostService.java
@@ -93,18 +93,16 @@ public class PostService {
 
   private Place findOrCreatePlace(PostCreateCommand command) {
     PlaceCommand placeReq = command.place();
-    Place findPlace =
-        placeRepository
-            .findByNameAndAddress(placeReq.name(), placeReq.address())
-            .orElseGet(
-                () ->
-                    placeRepository.save(
-                        Place.of(
-                            placeReq.name(),
-                            placeReq.address(),
-                            placeReq.latitude(),
-                            placeReq.longitude())));
-    return findPlace;
+    return placeRepository
+        .findByNameAndAddress(placeReq.name(), placeReq.address())
+        .orElseGet(
+            () ->
+                placeRepository.save(
+                    Place.of(
+                        placeReq.name(),
+                        placeReq.address(),
+                        placeReq.latitude(),
+                        placeReq.longitude())));
   }
 
   private PlaceCategory findPlaceCategory(PostCreateCommand command) {

--- a/src/main/java/com/plog/plogbackend/domain/post/service/dto/PostUpdateCommand.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/service/dto/PostUpdateCommand.java
@@ -1,0 +1,23 @@
+package com.plog.plogbackend.domain.post.service.dto;
+
+import com.plog.plogbackend.domain.post.entity.PublicScope;
+import com.plog.plogbackend.domain.post.enums.PlaceCategoryCode;
+import com.plog.plogbackend.domain.tag.enums.PlaceTag;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record PostUpdateCommand(
+    Long postId,
+    UUID memberKey,
+    String title,
+    String contents,
+    TimePickerCommand startedAt,
+    TimePickerCommand endedAt,
+    LocalDate studyDate,
+    Integer focus,
+    PublicScope scope,
+    PlaceCommand place,
+    List<PlaceTag> placeTags,
+    PlaceCategoryCode categoryCode,
+    List<Long> keepImageIds) {}

--- a/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
+++ b/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
@@ -48,6 +48,7 @@ public enum ErrorType {
   // 도메인 NOT_FOUND 세분화
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 회원을 찾을 수 없습니다.", LogLevel.WARN),
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 게시글을 찾을 수 없습니다.", LogLevel.WARN),
+  POST_FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "본인의 게시글만 조회/수정할 수 있습니다.", LogLevel.WARN),
   TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 약관을 찾을 수 없습니다.", LogLevel.WARN),
   REQUIRED_TERMS_NOT_AGREED(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "필수 약관에 동의해야 합니다.", LogLevel.WARN),


### PR DESCRIPTION
PR 개요
- `PostEntity`에 대한 조회(GET), 수정(PUT), 삭제(DELETE) API를 구현했습니다.

세부 작업 내용
- [x] **GET PostEntity**
  - [x] 단건 조회 API 엔드포인트 구현
  - [x] (필요시) 다건/페이징 조회 API 구현
  - [x] 존재하지 않는 자원 요청 시 예외 처리 (예: `PostNotFoundException`)
- [x] **PUT PostEntity**
  - [x] 전체/부분 수정 API 엔드포인트 구현
  - [x] 변경 감지(Dirty Checking)를 활용한 수정 로직 적용
  - [x] 수정 권한 검증 로직 추가 (필요 시)
- [x] **DELETE PostEntity**
  - [x] 삭제 API 엔드포인트 구현
  - [x] 하드 삭제(Hard Delete) / 소프트 삭제(Soft Delete) 정책에 맞게 로직 적용
  - [x] 연관된 자원(예: 댓글, 이미지 등)의 Cascade 처리 또는 고아 객체 제거 확인