### PR TITLE
PlaceReview 도메인 생성 및 crud 생성 

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/FeedDetailResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/post/controller/dto/response/FeedDetailResponse.java
@@ -15,6 +15,8 @@ public record FeedDetailResponse(
     String profileImage,
     //    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
     LocalDateTime createAt,
+    TimePickerResponse startedAt,
+    TimePickerResponse endedAt,
     List<String> postImages,
     Long likes,
     String title,
@@ -39,6 +41,8 @@ public record FeedDetailResponse(
         post.getMember().getNickname(),
         post.getMember().getProfileImage(),
         post.getCreatedAt(),
+        TimePickerResponse.from(post.getStartedAt()),
+        TimePickerResponse.from(post.getEndedAt()),
         post.getImages().stream().map(PostImage::getImageUrl).toList(),
         post.getLikes(),
         post.getTitle(),

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
@@ -1,4 +1,58 @@
 package com.plog.plogbackend.domain.review.controller;
 
+import com.plog.plogbackend.domain.review.controller.api.PlaceReviewMapper;
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewCreateRequest;
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
+import com.plog.plogbackend.domain.review.service.PlaceReviewCommandService;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import com.plog.plogbackend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "장소 리뷰", description = "장소 리뷰 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feed/review")
 public class PlaceReviewController {
+
+  private final PlaceReviewCommandService placeReviewCommandService;
+
+  @Operation(summary = "장소 리뷰 생성", description = "장소 리뷰 정보와 이미지를 함께 업로드합니다. (이미지 최대 5개)")
+  @PostMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ApiResponse<PlaceReviewResponse>> createReview(
+      @PathVariable Long postId,
+      @Parameter(description = "장소 리뷰 텍스트 데이터") @RequestPart("request") @Valid
+          PlaceReviewCreateRequest request,
+      @Parameter(description = "장소 리뷰 이미지 (최대 5개)") @RequestPart(value = "images", required = false)
+          List<MultipartFile> images,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+    PlaceReviewCreateCommand command = PlaceReviewMapper.from(postId, request, memberKey);
+    PlaceReviewResponse response = placeReviewCommandService.create(command, images);
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "장소 리뷰 수정", description = "장소 리뷰 별점, 환경 점수, 내용을 수정합니다. (작성 후 30일 이내)")
+  @PutMapping("/{reviewId}")
+  public ResponseEntity<ApiResponse<PlaceReviewResponse>> updateReview(
+      @PathVariable Long reviewId,
+      @Parameter(description = "장소 리뷰 수정 데이터") @RequestBody @Valid PlaceReviewUpdateRequest request,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+    PlaceReviewUpdateCommand command = PlaceReviewMapper.from(reviewId, request, memberKey);
+    PlaceReviewResponse response = placeReviewCommandService.update(command);
+
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.controller;
+
+public class PlaceReviewController {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
@@ -6,6 +6,7 @@ import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
 import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
 import com.plog.plogbackend.domain.review.service.PlaceReviewCommandService;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
 import com.plog.plogbackend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,15 +45,34 @@ public class PlaceReviewController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @Operation(summary = "장소 리뷰 수정", description = "장소 리뷰 별점, 환경 점수, 내용을 수정합니다. (작성 후 30일 이내)")
-  @PutMapping("/{reviewId}")
+  @Operation(
+      summary = "장소 리뷰 수정",
+      description =
+          "장소 리뷰 별점, 환경 점수, 내용과 이미지를 수정합니다. keepImageIds로 유지할 기존 이미지를 지정하고, "
+              + "images로 새 이미지를 업로드합니다. (작성 후 30일 이내, 총합 5개 이하)")
+  @PutMapping(value = "/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ApiResponse<PlaceReviewResponse>> updateReview(
       @PathVariable Long reviewId,
-      @Parameter(description = "장소 리뷰 수정 데이터") @RequestBody @Valid PlaceReviewUpdateRequest request,
+      @Parameter(description = "장소 리뷰 수정 데이터") @RequestPart("request") @Valid
+          PlaceReviewUpdateRequest request,
+      @Parameter(description = "새로 추가된 리뷰 이미지 (옵션)")
+          @RequestPart(value = "images", required = false)
+          List<MultipartFile> images,
       @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
     PlaceReviewUpdateCommand command = PlaceReviewMapper.from(reviewId, request, memberKey);
-    PlaceReviewResponse response = placeReviewCommandService.update(command);
+    PlaceReviewResponse response = placeReviewCommandService.update(command, images);
 
     return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "장소 리뷰 삭제", description = "본인 장소 리뷰를 삭제 상태로 변경합니다.")
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<ApiResponse<Void>> deleteReview(
+      @PathVariable Long reviewId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+    PlaceReviewDeleteCommand command = PlaceReviewMapper.from(reviewId, memberKey);
+    placeReviewCommandService.delete(command);
+
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapper.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapper.java
@@ -1,0 +1,22 @@
+package com.plog.plogbackend.domain.review.controller.api;
+
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewCreateRequest;
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import java.util.UUID;
+
+public class PlaceReviewMapper {
+
+  public static PlaceReviewCreateCommand from(
+      Long postId, PlaceReviewCreateRequest request, UUID memberKey) {
+    return new PlaceReviewCreateCommand(
+        postId, memberKey, request.rating(), request.content(), request.environments().toMap());
+  }
+
+  public static PlaceReviewUpdateCommand from(
+      Long reviewId, PlaceReviewUpdateRequest request, UUID memberKey) {
+    return new PlaceReviewUpdateCommand(
+        reviewId, memberKey, request.rating(), request.content(), request.environments().toMap());
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapper.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapper.java
@@ -3,6 +3,7 @@ package com.plog.plogbackend.domain.review.controller.api;
 import com.plog.plogbackend.domain.review.dto.request.PlaceReviewCreateRequest;
 import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
 import java.util.UUID;
 
@@ -17,6 +18,15 @@ public class PlaceReviewMapper {
   public static PlaceReviewUpdateCommand from(
       Long reviewId, PlaceReviewUpdateRequest request, UUID memberKey) {
     return new PlaceReviewUpdateCommand(
-        reviewId, memberKey, request.rating(), request.content(), request.environments().toMap());
+        reviewId,
+        memberKey,
+        request.rating(),
+        request.content(),
+        request.environments().toMap(),
+        request.keepImageIds());
+  }
+
+  public static PlaceReviewDeleteCommand from(Long reviewId, UUID memberKey) {
+    return new PlaceReviewDeleteCommand(reviewId, memberKey);
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewCreateRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewCreateRequest.java
@@ -1,0 +1,26 @@
+package com.plog.plogbackend.domain.review.dto.reqeust;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record PlaceReviewCreateRequest(
+        @NotNull @Min(1) @Max(5)
+        Integer rating,
+
+        @NotNull
+        LocalDate visitedDate,
+
+        LocalTime visitStartTime,
+        LocalTime visitEndTime,
+
+        List<String> environments,
+
+        @Size(max = 1000)
+        String content
+) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewUpdateRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewUpdateRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record PlaceReviewUpdateRequest(
     @Schema(description = "장소 리뷰 별점", example = "4") @NotNull @Min(1) @Max(5) Integer rating,
@@ -16,4 +17,5 @@ public record PlaceReviewUpdateRequest(
     @Schema(description = "장소 리뷰 내용", example = "다시 보니 조용하고 집중하기 좋았어요.")
         @NotBlank
         @Size(max = CONTENT_MAX_LENGTH)
-        String content) {}
+        String content,
+    @Schema(description = "유지할 기존 리뷰 이미지 ID 목록 (없으면 빈 배열)") @NotNull List<Long> keepImageIds) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewUpdateRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/request/PlaceReviewUpdateRequest.java
@@ -10,12 +10,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record PlaceReviewCreateRequest(
-    /** POST요청으로 별점,장소 환경,후기,이미지 */
-    @Schema(description = "장소 리뷰 별점", example = "5") @NotNull @Min(1) @Max(5) Integer rating,
+public record PlaceReviewUpdateRequest(
+    @Schema(description = "장소 리뷰 별점", example = "4") @NotNull @Min(1) @Max(5) Integer rating,
     @Schema(description = "장소 환경 점수") @Valid @NotNull ReviewEnvironmentRequest environments,
-    /** 컨텍츠 최대 길이 300 * */
-    @Schema(description = "장소 리뷰 내용", example = "집중하기 좋은 공간이었어요.")
+    @Schema(description = "장소 리뷰 내용", example = "다시 보니 조용하고 집중하기 좋았어요.")
         @NotBlank
         @Size(max = CONTENT_MAX_LENGTH)
         String content) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/request/ReviewEnvironmentRequest.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/request/ReviewEnvironmentRequest.java
@@ -1,0 +1,25 @@
+package com.plog.plogbackend.domain.review.dto.request;
+
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.EnumMap;
+import java.util.Map;
+
+public record ReviewEnvironmentRequest(
+    @Schema(description = "공간 크기 점수", example = "5") @NotNull @Min(1) @Max(5) Integer spaceSize,
+    @Schema(description = "소음 수준 점수", example = "4") @NotNull @Min(1) @Max(5) Integer noiseLevel,
+    @Schema(description = "혼잡도 점수", example = "3") @NotNull @Min(1) @Max(5) Integer congestionLevel,
+    @Schema(description = "집중도 점수", example = "5") @NotNull @Min(1) @Max(5) Integer focusLevel) {
+
+  public Map<ReviewEnvironmentName, Integer> toMap() {
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, spaceSize);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, noiseLevel);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, congestionLevel);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, focusLevel);
+    return environments;
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewResponse.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+public class PlaceReviewResponse {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewResponse.java
@@ -1,4 +1,49 @@
 package com.plog.plogbackend.domain.review.dto.response;
 
-public class PlaceReviewResponse {
+import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+@Builder
+public record PlaceReviewResponse(
+    Long reviewId,
+    Long postId,
+    Long placeId,
+    String placeName,
+    Integer rating,
+    LocalDate visitedDate,
+    LocalTime visitStartTime,
+    LocalTime visitEndTime,
+    Map<ReviewEnvironmentName, Integer> environments,
+    String content,
+    List<String> imageUrls) {
+
+  public static PlaceReviewResponse from(PlaceReview placeReview, List<ImageUrlResponse> images) {
+    return PlaceReviewResponse.builder()
+        .reviewId(placeReview.getId())
+        .postId(placeReview.getPost().getId())
+        .placeId(placeReview.getPost().getPlace().getId())
+        .placeName(placeReview.getPost().getPlace().getName())
+        .rating(placeReview.getRating())
+        .visitedDate(placeReview.getPost().getStudyDate())
+        .visitStartTime(placeReview.getPost().getStartedAt().toLocalTime())
+        .visitEndTime(placeReview.getPost().getEndedAt().toLocalTime())
+        .environments(placeReview.getEnvironments())
+        .content(placeReview.getContent())
+        .imageUrls(toImageUrls(images))
+        .build();
+  }
+
+  private static List<String> toImageUrls(List<ImageUrlResponse> images) {
+    if (images == null || images.isEmpty()) {
+      return List.of();
+    }
+
+    return images.stream().map(ImageUrlResponse::imageUrl).toList();
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.entity;
+
+public class PlaceReview {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
@@ -104,6 +104,19 @@ public class PlaceReview extends BaseTimeStatusEntity {
     deleteEntity();
   }
 
+  public void restore(
+      Integer rating,
+      String content,
+      Map<ReviewEnvironmentName, Integer> environments,
+      LocalDateTime now) {
+    restoreEntity();
+    this.rating = rating;
+    this.content = content;
+    this.editableUntil = now.plusDays(EDITABLE_DAYS);
+    this.environments.clear();
+    addEnvironments(environments);
+  }
+
   public Map<ReviewEnvironmentName, Integer> getEnvironments() {
     Map<ReviewEnvironmentName, Integer> environmentScores =
         new EnumMap<>(ReviewEnvironmentName.class);

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
@@ -1,4 +1,127 @@
 package com.plog.plogbackend.domain.review.entity;
 
-public class PlaceReview {
+import com.plog.plogbackend.domain.member.Member;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
+import com.plog.plogbackend.global.common.entity.BaseTimeStatusEntity;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceReview extends BaseTimeStatusEntity {
+
+  public static final int CONTENT_MAX_LENGTH = 300;
+  private static final long EDITABLE_DAYS = 30;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false, unique = true)
+  private Post post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @Column(nullable = false)
+  private Integer rating;
+
+  @Column(length = CONTENT_MAX_LENGTH)
+  private String content;
+
+  @Column(nullable = false)
+  private LocalDateTime editableUntil;
+
+  @OneToMany(mappedBy = "placeReview", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<PlaceReviewEnvironment> environments = new ArrayList<>();
+
+  private PlaceReview(
+      Post post,
+      Member member,
+      Integer rating,
+      String content,
+      Map<ReviewEnvironmentName, Integer> environments) {
+    this.post = post;
+    this.member = member;
+    this.rating = rating;
+    this.content = content;
+    addEnvironments(environments);
+  }
+
+  public static PlaceReview create(
+      Post post,
+      Member member,
+      Integer rating,
+      String content,
+      Map<ReviewEnvironmentName, Integer> environments) {
+    return new PlaceReview(post, member, rating, content, environments);
+  }
+
+  @PrePersist
+  private void setEditableUntil() {
+    if (editableUntil == null) {
+      editableUntil = LocalDateTime.now().plusDays(EDITABLE_DAYS);
+    }
+  }
+
+  public boolean isEditable(LocalDateTime now) {
+    return getStatus() == EntityStatus.ACTIVE && !now.isAfter(editableUntil);
+  }
+
+  public void validateEditable(LocalDateTime now) {
+    if (!isEditable(now)) {
+      throw new AppException(ErrorType.PLACE_REVIEW_EDIT_PERIOD_EXPIRED);
+    }
+  }
+
+  public void update(
+      Integer rating,
+      String content,
+      Map<ReviewEnvironmentName, Integer> environments,
+      LocalDateTime now) {
+    validateEditable(now);
+    this.rating = rating;
+    this.content = content;
+    this.environments.clear();
+    addEnvironments(environments);
+  }
+
+  public void delete() {
+    deleteEntity();
+  }
+
+  public Map<ReviewEnvironmentName, Integer> getEnvironments() {
+    Map<ReviewEnvironmentName, Integer> environmentScores =
+        new EnumMap<>(ReviewEnvironmentName.class);
+    environments.forEach(
+        environment -> environmentScores.put(environment.getName(), environment.getScore()));
+    return environmentScores;
+  }
+
+  private void addEnvironments(Map<ReviewEnvironmentName, Integer> environments) {
+    if (environments == null || environments.isEmpty()) {
+      return;
+    }
+
+    environments.forEach(
+        (name, score) -> {
+          if (name != null && score != null) {
+            this.environments.add(PlaceReviewEnvironment.of(this, name, score));
+          }
+        });
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironment.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironment.java
@@ -1,0 +1,46 @@
+package com.plog.plogbackend.domain.review.entity;
+
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "place_review_environment",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_place_review_environment_review_name",
+            columnNames = {"review_id", "environment_name"}))
+public class PlaceReviewEnvironment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "review_id", nullable = false)
+  private PlaceReview placeReview;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "environment_name", nullable = false)
+  private ReviewEnvironmentName name;
+
+  @Column(name = "score", nullable = false)
+  private Integer score;
+
+  private PlaceReviewEnvironment(
+      PlaceReview placeReview, ReviewEnvironmentName name, Integer score) {
+    this.placeReview = placeReview;
+    this.name = name;
+    this.score = score;
+  }
+
+  static PlaceReviewEnvironment of(
+      PlaceReview placeReview, ReviewEnvironmentName name, Integer score) {
+    return new PlaceReviewEnvironment(placeReview, name, score);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewImage.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewImage.java
@@ -1,4 +1,32 @@
 package com.plog.plogbackend.domain.review.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaceReviewImage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "place_review_id", nullable = false)
+  private PlaceReview placeReview;
+
+  @Column(nullable = false)
+  private String imageUrl;
+
+  private PlaceReviewImage(PlaceReview placeReview, String imageUrl) {
+    this.placeReview = placeReview;
+    this.imageUrl = imageUrl;
+  }
+
+  public static PlaceReviewImage of(PlaceReview placeReview, String imageUrl) {
+    return new PlaceReviewImage(placeReview, imageUrl);
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewImage.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewImage.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.entity;
+
+public class PlaceReviewImage {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/enums/ReviewEnvironmentName.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/enums/ReviewEnvironmentName.java
@@ -1,0 +1,91 @@
+package com.plog.plogbackend.domain.review.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewEnvironmentName {
+
+  /**
+   * 프론트 요청 api { "environments": { "spaceSize": 5, "noiseLevel": 4, "congestionLevel": 3,
+   * "focusLevel": 5 } }
+   */
+  SPACE_SIZE(
+      "spaceSize",
+      "공간 크기",
+      "company-filled",
+      Map.of(
+          5, "매우 넓어요",
+          4, "넓은 편이에요",
+          3, "보통이에요",
+          2, "좁은 편이에요",
+          1, "매우 좁아요")),
+
+  NOISE_LEVEL(
+      "noiseLevel",
+      "소음 수준",
+      "megaphone-filled",
+      Map.of(
+          5, "매우 조용해요",
+          4, "조용한 편이에요",
+          3, "보통이에요",
+          2, "시끄러운 편이에요",
+          1, "매우 시끄러워요")),
+
+  CONGESTION_LEVEL(
+      "congestionLevel",
+      "혼잡도",
+      "smile-filled",
+      Map.of(
+          5, "여유로워요",
+          4, "여유 있는 편이에요",
+          3, "보통이에요",
+          2, "붐비는 편이에요",
+          1, "매우 붐벼요")),
+
+  FOCUS_LEVEL(
+      "focusLevel",
+      "집중도",
+      "fire-filled",
+      Map.of(
+          5, "매우 잘 돼요",
+          4, "잘 되는 편이에요",
+          3, "보통이에요",
+          2, "잘 안 돼요",
+          1, "전혀 안 돼요"));
+
+  private final String value;
+  private final String title;
+  private final String iconName;
+  private final Map<Integer, String> labels;
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static ReviewEnvironmentName fromValue(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+
+    return Arrays.stream(values())
+        .filter(environment -> environment.value.equals(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 리뷰 환경 항목입니다: " + value));
+  }
+
+  public String getLabel(int score) {
+    String label = labels.get(score);
+    if (label == null) {
+      throw new IllegalArgumentException("지원하지 않는 리뷰 환경 점수입니다: " + score);
+    }
+    return label;
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.repository;
+
+public interface PlaceReviewImageRepository {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
@@ -1,4 +1,9 @@
 package com.plog.plogbackend.domain.review.repository;
 
-public interface PlaceReviewImageRepository {
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewImageRepository extends JpaRepository<PlaceReviewImage, Long> {
+  List<PlaceReviewImage> findAllByPlaceReviewId(Long placeReviewId);
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
@@ -1,4 +1,12 @@
 package com.plog.plogbackend.domain.review.repository;
 
-public interface PlaceReviewRepository {
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> {
+
+  boolean existsByPostId(Long postId);
+
+  Optional<PlaceReview> findByPostId(Long postId);
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.repository;
+
+public interface PlaceReviewRepository {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewRepository.java
@@ -1,6 +1,7 @@
 package com.plog.plogbackend.domain.review.repository;
 
 import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long> 
   boolean existsByPostId(Long postId);
 
   Optional<PlaceReview> findByPostId(Long postId);
+
+  Optional<PlaceReview> findByIdAndStatus(Long id, EntityStatus status);
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandService.java
@@ -4,6 +4,7 @@ import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
 import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
 import com.plog.plogbackend.domain.review.entity.PlaceReview;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,16 +26,22 @@ public class PlaceReviewCommandService {
     PlaceReview placeReview = placeReviewService.create(command);
 
     List<ImageUrlResponse> uploadedImages =
-        placeReviewImageService.uploadPlaceReviewImages(placeReview.getId(), images);
+        placeReviewImageService.replacePlaceReviewImages(placeReview.getId(), List.of(), images);
 
     return PlaceReviewResponse.from(placeReview, uploadedImages);
   }
 
   @Transactional
-  public PlaceReviewResponse update(PlaceReviewUpdateCommand command) {
+  public PlaceReviewResponse update(PlaceReviewUpdateCommand command, List<MultipartFile> images) {
     PlaceReview placeReview = placeReviewService.update(command);
-    List<ImageUrlResponse> images =
-        placeReviewImageService.getPlaceReviewImages(placeReview.getId());
-    return PlaceReviewResponse.from(placeReview, images);
+    List<ImageUrlResponse> imageResponses =
+        placeReviewImageService.replacePlaceReviewImages(
+            placeReview.getId(), command.keepImageIds(), images);
+    return PlaceReviewResponse.from(placeReview, imageResponses);
+  }
+
+  @Transactional
+  public void delete(PlaceReviewDeleteCommand command) {
+    placeReviewService.delete(command);
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandService.java
@@ -1,0 +1,40 @@
+package com.plog.plogbackend.domain.review.service;
+
+import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceReviewCommandService {
+
+  private final PlaceReviewService placeReviewService;
+  private final PlaceReviewImageService placeReviewImageService;
+
+  @Transactional
+  public PlaceReviewResponse create(PlaceReviewCreateCommand command, List<MultipartFile> images) {
+    placeReviewImageService.validateImages(images);
+
+    PlaceReview placeReview = placeReviewService.create(command);
+
+    List<ImageUrlResponse> uploadedImages =
+        placeReviewImageService.uploadPlaceReviewImages(placeReview.getId(), images);
+
+    return PlaceReviewResponse.from(placeReview, uploadedImages);
+  }
+
+  @Transactional
+  public PlaceReviewResponse update(PlaceReviewUpdateCommand command) {
+    PlaceReview placeReview = placeReviewService.update(command);
+    List<ImageUrlResponse> images =
+        placeReviewImageService.getPlaceReviewImages(placeReview.getId());
+    return PlaceReviewResponse.from(placeReview, images);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
@@ -5,14 +5,20 @@ import com.plog.plogbackend.domain.review.entity.PlaceReview;
 import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
 import com.plog.plogbackend.domain.review.repository.PlaceReviewImageRepository;
 import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
 import com.plog.plogbackend.global.error.AppException;
 import com.plog.plogbackend.global.error.ErrorType;
 import com.plog.plogbackend.global.util.GcsService;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -34,10 +40,7 @@ public class PlaceReviewImageService {
 
     validateImages(images);
 
-    PlaceReview placeReview =
-        placeReviewRepository
-            .findById(placeReviewId)
-            .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
+    PlaceReview placeReview = findActivePlaceReview(placeReviewId);
 
     List<String> uploadedUrls = new ArrayList<>();
     List<ImageUrlResponse> responses = new ArrayList<>();
@@ -56,6 +59,59 @@ public class PlaceReviewImageService {
     }
   }
 
+  public List<ImageUrlResponse> replacePlaceReviewImages(
+      Long placeReviewId, List<Long> keepImageIds, List<MultipartFile> newImages) {
+    PlaceReview placeReview = findActivePlaceReview(placeReviewId);
+
+    List<Long> safeKeepIds = keepImageIds == null ? List.of() : keepImageIds;
+    List<MultipartFile> safeNewImages =
+        newImages == null
+            ? List.of()
+            : newImages.stream().filter(image -> image != null && !image.isEmpty()).toList();
+
+    validateTotalImageCount(safeKeepIds.size(), safeNewImages.size());
+
+    List<PlaceReviewImage> currentImages =
+        placeReviewImageRepository.findAllByPlaceReviewId(placeReviewId);
+    Set<Long> currentImageIds =
+        currentImages.stream().map(PlaceReviewImage::getId).collect(Collectors.toSet());
+
+    if (!currentImageIds.containsAll(safeKeepIds)) {
+      throw new AppException(ErrorType.INVALID_ACCESS_PATH);
+    }
+
+    Set<Long> keepImageIdSet = new HashSet<>(safeKeepIds);
+    List<ImageUrlResponse> responses = new ArrayList<>();
+    List<PlaceReviewImage> deleteImages = new ArrayList<>();
+
+    for (PlaceReviewImage image : currentImages) {
+      if (keepImageIdSet.contains(image.getId())) {
+        responses.add(new ImageUrlResponse(image.getImageUrl()));
+        continue;
+      }
+
+      deleteImages.add(image);
+    }
+
+    List<String> uploadedUrls = new ArrayList<>();
+    List<String> deleteUrls = deleteImages.stream().map(PlaceReviewImage::getImageUrl).toList();
+    try {
+      for (MultipartFile image : safeNewImages) {
+        String imageUrl = gcsService.upload(image, PLACE_REVIEW_DIR);
+        uploadedUrls.add(imageUrl);
+        placeReviewImageRepository.save(PlaceReviewImage.of(placeReview, imageUrl));
+        responses.add(new ImageUrlResponse(imageUrl));
+      }
+
+      deleteImages.forEach(placeReviewImageRepository::delete);
+      registerGcsCleanup(uploadedUrls, deleteUrls);
+      return responses;
+    } catch (RuntimeException e) {
+      uploadedUrls.forEach(gcsService::delete);
+      throw e;
+    }
+  }
+
   public void validateImages(List<MultipartFile> images) {
     if (images == null || images.isEmpty()) {
       return;
@@ -64,6 +120,40 @@ public class PlaceReviewImageService {
     if (images.size() > PLACE_REVIEW_IMAGE_MAX) {
       throw new AppException(ErrorType.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
     }
+  }
+
+  private void validateTotalImageCount(int keepImageCount, int newImageCount) {
+    if (keepImageCount + newImageCount > PLACE_REVIEW_IMAGE_MAX) {
+      throw new AppException(ErrorType.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
+    }
+  }
+
+  private PlaceReview findActivePlaceReview(Long placeReviewId) {
+    return placeReviewRepository
+        .findByIdAndStatus(placeReviewId, EntityStatus.ACTIVE)
+        .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
+  }
+
+  private void registerGcsCleanup(List<String> uploadedUrls, List<String> deleteUrls) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      deleteUrls.forEach(gcsService::delete);
+      return;
+    }
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            deleteUrls.forEach(gcsService::delete);
+          }
+
+          @Override
+          public void afterCompletion(int status) {
+            if (status == STATUS_ROLLED_BACK) {
+              uploadedUrls.forEach(gcsService::delete);
+            }
+          }
+        });
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
@@ -1,0 +1,75 @@
+package com.plog.plogbackend.domain.review.service;
+
+import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewImageRepository;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import com.plog.plogbackend.global.util.GcsService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceReviewImageService {
+
+  private static final String PLACE_REVIEW_DIR = "place-reviews";
+  private static final int PLACE_REVIEW_IMAGE_MAX = 5;
+
+  private final GcsService gcsService;
+  private final PlaceReviewRepository placeReviewRepository;
+  private final PlaceReviewImageRepository placeReviewImageRepository;
+
+  public List<ImageUrlResponse> uploadPlaceReviewImages(
+      Long placeReviewId, List<MultipartFile> images) {
+    if (images == null || images.isEmpty()) {
+      return List.of();
+    }
+
+    validateImages(images);
+
+    PlaceReview placeReview =
+        placeReviewRepository
+            .findById(placeReviewId)
+            .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
+
+    List<String> uploadedUrls = new ArrayList<>();
+    List<ImageUrlResponse> responses = new ArrayList<>();
+
+    try {
+      for (MultipartFile image : images) {
+        String imageUrl = gcsService.upload(image, PLACE_REVIEW_DIR);
+        uploadedUrls.add(imageUrl);
+        placeReviewImageRepository.save(PlaceReviewImage.of(placeReview, imageUrl));
+        responses.add(new ImageUrlResponse(imageUrl));
+      }
+      return responses;
+    } catch (RuntimeException e) {
+      uploadedUrls.forEach(gcsService::delete);
+      throw e;
+    }
+  }
+
+  public void validateImages(List<MultipartFile> images) {
+    if (images == null || images.isEmpty()) {
+      return;
+    }
+
+    if (images.size() > PLACE_REVIEW_IMAGE_MAX) {
+      throw new AppException(ErrorType.PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED);
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public List<ImageUrlResponse> getPlaceReviewImages(Long placeReviewId) {
+    return placeReviewImageRepository.findAllByPlaceReviewId(placeReviewId).stream()
+        .map(image -> new ImageUrlResponse(image.getImageUrl()))
+        .toList();
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
@@ -1,4 +1,83 @@
 package com.plog.plogbackend.domain.review.service;
 
+import com.plog.plogbackend.domain.member.Member;
+import com.plog.plogbackend.domain.member.repository.MemberRepository;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.repository.PostRepository;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class PlaceReviewService {
+
+  private final MemberRepository memberRepository;
+  private final PostRepository postRepository;
+  private final PlaceReviewRepository placeReviewRepository;
+
+  @Transactional
+  public PlaceReview create(PlaceReviewCreateCommand command) {
+
+    Member member = findMember(command.memberKey());
+    Post post = findPost(command.postId());
+
+    validatePostOwner(post, member);
+    validateDuplicatedReview(command.postId());
+
+    return placeReviewRepository.save(
+        PlaceReview.create(
+            post, member, command.rating(), command.content(), command.environments()));
+  }
+
+  @Transactional
+  public PlaceReview update(PlaceReviewUpdateCommand command) {
+    PlaceReview placeReview =
+        placeReviewRepository
+            .findById(command.reviewId())
+            .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
+
+    validateReviewOwner(placeReview, command.memberKey());
+    placeReview.update(
+        command.rating(), command.content(), command.environments(), LocalDateTime.now());
+    return placeReview;
+  }
+
+  private Member findMember(UUID memberKey) {
+    return memberRepository
+        .findByMemberKey(memberKey)
+        .orElseThrow(() -> new AppException(ErrorType.MEMBER_NOT_FOUND));
+  }
+
+  private Post findPost(Long postId) {
+    return postRepository
+        .findById(postId)
+        .orElseThrow(() -> new AppException(ErrorType.POST_NOT_FOUND));
+  }
+
+  private void validatePostOwner(Post post, Member member) {
+    if (!post.getMember().getId().equals(member.getId())) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+  }
+
+  private void validateReviewOwner(PlaceReview placeReview, UUID memberKey) {
+    if (!placeReview.getMember().getMemberKey().equals(memberKey)) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+  }
+
+  private void validateDuplicatedReview(Long postId) {
+    if (placeReviewRepository.existsByPostId(postId)) {
+      throw new AppException(ErrorType.PLACE_REVIEW_ALREADY_EXISTS);
+    }
+  }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
@@ -1,0 +1,4 @@
+package com.plog.plogbackend.domain.review.service;
+
+public class PlaceReviewService {
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewService.java
@@ -7,7 +7,9 @@ import com.plog.plogbackend.domain.post.repository.PostRepository;
 import com.plog.plogbackend.domain.review.entity.PlaceReview;
 import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
 import com.plog.plogbackend.global.error.AppException;
 import com.plog.plogbackend.global.error.ErrorType;
 import java.time.LocalDateTime;
@@ -26,29 +28,39 @@ public class PlaceReviewService {
 
   @Transactional
   public PlaceReview create(PlaceReviewCreateCommand command) {
-
     Member member = findMember(command.memberKey());
     Post post = findPost(command.postId());
 
     validatePostOwner(post, member);
-    validateDuplicatedReview(command.postId());
 
-    return placeReviewRepository.save(
-        PlaceReview.create(
-            post, member, command.rating(), command.content(), command.environments()));
+    return placeReviewRepository
+        .findByPostId(command.postId())
+        .map(existingReview -> recreateOrThrow(existingReview, command))
+        .orElseGet(() -> saveNewReview(post, member, command));
   }
 
   @Transactional
   public PlaceReview update(PlaceReviewUpdateCommand command) {
     PlaceReview placeReview =
         placeReviewRepository
-            .findById(command.reviewId())
+            .findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE)
             .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
 
     validateReviewOwner(placeReview, command.memberKey());
     placeReview.update(
         command.rating(), command.content(), command.environments(), LocalDateTime.now());
     return placeReview;
+  }
+
+  @Transactional
+  public void delete(PlaceReviewDeleteCommand command) {
+    PlaceReview placeReview =
+        placeReviewRepository
+            .findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE)
+            .orElseThrow(() -> new AppException(ErrorType.NOT_FOUND));
+
+    validateReviewOwner(placeReview, command.memberKey());
+    placeReview.delete();
   }
 
   private Member findMember(UUID memberKey) {
@@ -75,9 +87,20 @@ public class PlaceReviewService {
     }
   }
 
-  private void validateDuplicatedReview(Long postId) {
-    if (placeReviewRepository.existsByPostId(postId)) {
+  private PlaceReview recreateOrThrow(
+      PlaceReview existingReview, PlaceReviewCreateCommand command) {
+    if (existingReview.getStatus() == EntityStatus.ACTIVE) {
       throw new AppException(ErrorType.PLACE_REVIEW_ALREADY_EXISTS);
     }
+
+    existingReview.restore(
+        command.rating(), command.content(), command.environments(), LocalDateTime.now());
+    return existingReview;
+  }
+
+  private PlaceReview saveNewReview(Post post, Member member, PlaceReviewCreateCommand command) {
+    return placeReviewRepository.save(
+        PlaceReview.create(
+            post, member, command.rating(), command.content(), command.environments()));
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewCreateCommand.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewCreateCommand.java
@@ -1,0 +1,12 @@
+package com.plog.plogbackend.domain.review.service.dto;
+
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import java.util.Map;
+import java.util.UUID;
+
+public record PlaceReviewCreateCommand(
+    Long postId,
+    UUID memberKey,
+    Integer rating,
+    String content,
+    Map<ReviewEnvironmentName, Integer> environments) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewDeleteCommand.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewDeleteCommand.java
@@ -1,0 +1,5 @@
+package com.plog.plogbackend.domain.review.service.dto;
+
+import java.util.UUID;
+
+public record PlaceReviewDeleteCommand(Long reviewId, UUID memberKey) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewUpdateCommand.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewUpdateCommand.java
@@ -1,0 +1,12 @@
+package com.plog.plogbackend.domain.review.service.dto;
+
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import java.util.Map;
+import java.util.UUID;
+
+public record PlaceReviewUpdateCommand(
+    Long reviewId,
+    UUID memberKey,
+    Integer rating,
+    String content,
+    Map<ReviewEnvironmentName, Integer> environments) {}

--- a/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewUpdateCommand.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/dto/PlaceReviewUpdateCommand.java
@@ -1,6 +1,7 @@
 package com.plog.plogbackend.domain.review.service.dto;
 
 import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -9,4 +10,5 @@ public record PlaceReviewUpdateCommand(
     UUID memberKey,
     Integer rating,
     String content,
-    Map<ReviewEnvironmentName, Integer> environments) {}
+    Map<ReviewEnvironmentName, Integer> environments,
+    List<Long> keepImageIds) {}

--- a/src/main/java/com/plog/plogbackend/global/common/entity/BaseTimeStatusEntity.java
+++ b/src/main/java/com/plog/plogbackend/global/common/entity/BaseTimeStatusEntity.java
@@ -34,4 +34,10 @@ public abstract class BaseTimeStatusEntity {
     this.status = EntityStatus.DELETED;
     this.deletedAt = LocalDateTime.now();
   }
+
+  /** 논리적 삭제 복구 */
+  protected void restoreEntity() {
+    this.status = EntityStatus.ACTIVE;
+    this.deletedAt = null;
+  }
 }

--- a/src/main/java/com/plog/plogbackend/global/error/ErrorCode.java
+++ b/src/main/java/com/plog/plogbackend/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
   E1103,
   E1104,
   E1105,
+  E1106,
 
   // 뱃지 관련
   E1200,

--- a/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
+++ b/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
@@ -97,7 +97,15 @@ public enum ErrorType {
   // 최신 검색 관련
   RECENT_SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "최근 검색을 찾을 수 없습니다.", LogLevel.WARN),
   RECENT_SEARCH_FORBIDDEN(
-      HttpStatus.FORBIDDEN, ErrorCode.E403, "본인의 검색 이력만 삭제할 수 있습니다.", LogLevel.WARN);
+      HttpStatus.FORBIDDEN, ErrorCode.E403, "본인의 검색 이력만 삭제할 수 있습니다.", LogLevel.WARN),
+
+  // 장소 리뷰 관련
+  PLACE_REVIEW_ALREADY_EXISTS(
+      HttpStatus.CONFLICT, ErrorCode.E409, "이미 작성된 장소 리뷰가 있습니다.", LogLevel.WARN),
+  PLACE_REVIEW_EDIT_PERIOD_EXPIRED(
+      HttpStatus.BAD_REQUEST, ErrorCode.E400, "장소 리뷰 수정 가능 기간이 만료되었습니다.", LogLevel.WARN),
+  PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(
+      HttpStatus.BAD_REQUEST, ErrorCode.E1106, "장소 리뷰 이미지는 최대 5개까지 업로드 가능합니다.", LogLevel.WARN);
 
   // 여기에 추가해주시고 사용하시면 됩니다.
 

--- a/src/test/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapperTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapperTest.java
@@ -7,7 +7,9 @@ import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
 import com.plog.plogbackend.domain.review.dto.request.ReviewEnvironmentRequest;
 import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +43,8 @@ class PlaceReviewMapperTest {
     Long reviewId = 10L;
     UUID memberKey = UUID.randomUUID();
     ReviewEnvironmentRequest environments = new ReviewEnvironmentRequest(1, 2, 3, 4);
-    PlaceReviewUpdateRequest request = new PlaceReviewUpdateRequest(3, environments, "수정한 리뷰입니다");
+    PlaceReviewUpdateRequest request =
+        new PlaceReviewUpdateRequest(3, environments, "수정한 리뷰입니다", List.of(1L, 2L));
 
     PlaceReviewUpdateCommand command = PlaceReviewMapper.from(reviewId, request, memberKey);
 
@@ -49,10 +52,23 @@ class PlaceReviewMapperTest {
     assertThat(command.memberKey()).isEqualTo(memberKey);
     assertThat(command.rating()).isEqualTo(3);
     assertThat(command.content()).isEqualTo("수정한 리뷰입니다");
+    assertThat(command.keepImageIds()).containsExactly(1L, 2L);
     assertThat(command.environments())
         .containsEntry(ReviewEnvironmentName.SPACE_SIZE, 1)
         .containsEntry(ReviewEnvironmentName.NOISE_LEVEL, 2)
         .containsEntry(ReviewEnvironmentName.CONGESTION_LEVEL, 3)
         .containsEntry(ReviewEnvironmentName.FOCUS_LEVEL, 4);
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 삭제 요청을 서비스 Command로 변환한다")
+  void fromDeleteRequest() {
+    Long reviewId = 10L;
+    UUID memberKey = UUID.randomUUID();
+
+    PlaceReviewDeleteCommand command = PlaceReviewMapper.from(reviewId, memberKey);
+
+    assertThat(command.reviewId()).isEqualTo(reviewId);
+    assertThat(command.memberKey()).isEqualTo(memberKey);
   }
 }

--- a/src/test/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapperTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/controller/api/PlaceReviewMapperTest.java
@@ -1,0 +1,58 @@
+package com.plog.plogbackend.domain.review.controller.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewCreateRequest;
+import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
+import com.plog.plogbackend.domain.review.dto.request.ReviewEnvironmentRequest;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlaceReviewMapperTest {
+
+  @Test
+  @DisplayName("장소 리뷰 생성 요청을 서비스 Command로 변환한다")
+  void fromCreateRequest() {
+    Long postId = 1L;
+    UUID memberKey = UUID.randomUUID();
+    ReviewEnvironmentRequest environments = new ReviewEnvironmentRequest(5, 4, 3, 2);
+    PlaceReviewCreateRequest request = new PlaceReviewCreateRequest(4, environments, "집중하기 좋았어요");
+
+    PlaceReviewCreateCommand command = PlaceReviewMapper.from(postId, request, memberKey);
+
+    assertThat(command.postId()).isEqualTo(postId);
+    assertThat(command.memberKey()).isEqualTo(memberKey);
+    assertThat(command.rating()).isEqualTo(4);
+    assertThat(command.content()).isEqualTo("집중하기 좋았어요");
+    assertThat(command.environments())
+        .containsEntry(ReviewEnvironmentName.SPACE_SIZE, 5)
+        .containsEntry(ReviewEnvironmentName.NOISE_LEVEL, 4)
+        .containsEntry(ReviewEnvironmentName.CONGESTION_LEVEL, 3)
+        .containsEntry(ReviewEnvironmentName.FOCUS_LEVEL, 2);
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 수정 요청을 서비스 Command로 변환한다")
+  void fromUpdateRequest() {
+    Long reviewId = 10L;
+    UUID memberKey = UUID.randomUUID();
+    ReviewEnvironmentRequest environments = new ReviewEnvironmentRequest(1, 2, 3, 4);
+    PlaceReviewUpdateRequest request = new PlaceReviewUpdateRequest(3, environments, "수정한 리뷰입니다");
+
+    PlaceReviewUpdateCommand command = PlaceReviewMapper.from(reviewId, request, memberKey);
+
+    assertThat(command.reviewId()).isEqualTo(reviewId);
+    assertThat(command.memberKey()).isEqualTo(memberKey);
+    assertThat(command.rating()).isEqualTo(3);
+    assertThat(command.content()).isEqualTo("수정한 리뷰입니다");
+    assertThat(command.environments())
+        .containsEntry(ReviewEnvironmentName.SPACE_SIZE, 1)
+        .containsEntry(ReviewEnvironmentName.NOISE_LEVEL, 2)
+        .containsEntry(ReviewEnvironmentName.CONGESTION_LEVEL, 3)
+        .containsEntry(ReviewEnvironmentName.FOCUS_LEVEL, 4);
+  }
+}

--- a/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEditPolicyTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEditPolicyTest.java
@@ -70,4 +70,32 @@ class PlaceReviewEditPolicyTest {
     assertThat(review.getStatus()).isEqualTo(EntityStatus.DELETED);
     assertThat(review.getDeletedAt()).isNotNull();
   }
+
+  @Test
+  @DisplayName("삭제된 장소 리뷰 복구 시 상태, 수정 가능 기간, 리뷰 내용을 새 작성 기준으로 갱신한다")
+  void restore_reactivatesReviewAndReplacesFields() {
+    PlaceReview review = PlaceReview.create(null, null, 5, "좋았어요", environments(5, 4, 3, 2));
+    review.delete();
+    LocalDateTime now = LocalDateTime.of(2026, 5, 20, 12, 0);
+    Map<ReviewEnvironmentName, Integer> newEnvironments = environments(1, 2, 3, 4);
+
+    review.restore(3, "다시 작성한 리뷰입니다", newEnvironments, now);
+
+    assertThat(review.getStatus()).isEqualTo(EntityStatus.ACTIVE);
+    assertThat(review.getDeletedAt()).isNull();
+    assertThat(review.getEditableUntil()).isEqualTo(now.plusDays(30));
+    assertThat(review.getRating()).isEqualTo(3);
+    assertThat(review.getContent()).isEqualTo("다시 작성한 리뷰입니다");
+    assertThat(review.getEnvironments()).containsExactlyInAnyOrderEntriesOf(newEnvironments);
+  }
+
+  private Map<ReviewEnvironmentName, Integer> environments(
+      int spaceSize, int noiseLevel, int congestionLevel, int focusLevel) {
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, spaceSize);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, noiseLevel);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, congestionLevel);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, focusLevel);
+    return environments;
+  }
 }

--- a/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEditPolicyTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEditPolicyTest.java
@@ -1,0 +1,73 @@
+package com.plog.plogbackend.domain.review.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PlaceReviewEditPolicyTest {
+
+  @Test
+  @DisplayName("장소 리뷰는 수정 가능 시각까지 수정 가능하다")
+  void isEditable_untilEditableUntil() {
+    PlaceReview review = PlaceReview.create(null, null, 5, "좋았어요", null);
+    LocalDateTime editableUntil = LocalDateTime.of(2026, 1, 31, 12, 0);
+    ReflectionTestUtils.setField(review, "editableUntil", editableUntil);
+
+    assertThat(review.isEditable(editableUntil.minusNanos(1))).isTrue();
+    assertThat(review.isEditable(editableUntil)).isTrue();
+    assertThat(review.isEditable(editableUntil.plusNanos(1))).isFalse();
+  }
+
+  @Test
+  @DisplayName("수정 가능 기간이 지나면 장소 리뷰 수정 검증에 실패한다")
+  void validateEditable_afterEditableUntil() {
+    PlaceReview review = PlaceReview.create(null, null, 5, "좋았어요", null);
+    LocalDateTime editableUntil = LocalDateTime.of(2026, 1, 31, 12, 0);
+    ReflectionTestUtils.setField(review, "editableUntil", editableUntil);
+
+    assertThatThrownBy(() -> review.validateEditable(editableUntil.plusNanos(1)))
+        .isInstanceOf(AppException.class)
+        .extracting("errorType")
+        .isEqualTo(ErrorType.PLACE_REVIEW_EDIT_PERIOD_EXPIRED);
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 수정 시 별점, 내용, 환경 점수를 변경한다")
+  void update_changesReviewFields() {
+    PlaceReview review = PlaceReview.create(null, null, 5, "좋았어요", null);
+    LocalDateTime editableUntil = LocalDateTime.of(2026, 1, 31, 12, 0);
+    ReflectionTestUtils.setField(review, "editableUntil", editableUntil);
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, 1);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, 2);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, 3);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, 4);
+
+    review.update(3, "수정한 리뷰입니다", environments, editableUntil);
+
+    assertThat(review.getRating()).isEqualTo(3);
+    assertThat(review.getContent()).isEqualTo("수정한 리뷰입니다");
+    assertThat(review.getEnvironments()).containsAllEntriesOf(environments);
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 삭제는 상태와 삭제 시각만 변경한다")
+  void delete_marksReviewDeleted() {
+    PlaceReview review = PlaceReview.create(null, null, 5, "좋았어요", null);
+
+    review.delete();
+
+    assertThat(review.getStatus()).isEqualTo(EntityStatus.DELETED);
+    assertThat(review.getDeletedAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironmentPersistenceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironmentPersistenceTest.java
@@ -1,0 +1,86 @@
+package com.plog.plogbackend.domain.review.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.plog.plogbackend.domain.member.Member;
+import com.plog.plogbackend.domain.member.repository.MemberRepository;
+import com.plog.plogbackend.domain.place.entity.Place;
+import com.plog.plogbackend.domain.place.repository.PlaceRepository;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.entity.PublicScope;
+import com.plog.plogbackend.domain.post.enums.PlaceCategoryCode;
+import com.plog.plogbackend.domain.post.repository.PostRepository;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PlaceReviewEnvironmentPersistenceTest {
+
+  @Autowired private PlaceReviewRepository placeReviewRepository;
+  @Autowired private PostRepository postRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private PlaceRepository placeRepository;
+  @Autowired private EntityManager em;
+
+  @Test
+  @DisplayName("장소 리뷰의 환경 점수는 PlaceReviewEnvironment 엔티티로 저장된다")
+  void savePlaceReview_persistsEnvironmentEntities() {
+    LocalDateTime beforeCreate = LocalDateTime.now();
+    Member member =
+        memberRepository.save(Member.createNewMember("reviewer", "provider-reviewer", null, null));
+    Place place = placeRepository.save(Place.of("테스트 카페", "서울시 강남구", 37.0, 127.0));
+    Post post = postRepository.save(createPost(member, place));
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, 5);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, 4);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, 3);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, 2);
+
+    PlaceReview review =
+        placeReviewRepository.save(PlaceReview.create(post, member, 5, "집중하기 좋았어요", environments));
+    em.flush();
+    LocalDateTime afterCreate = LocalDateTime.now();
+    em.clear();
+
+    Long environmentCount =
+        em.createQuery(
+                "select count(environment) from PlaceReviewEnvironment environment "
+                    + "where environment.placeReview.id = :reviewId",
+                Long.class)
+            .setParameter("reviewId", review.getId())
+            .getSingleResult();
+    PlaceReview foundReview = placeReviewRepository.findById(review.getId()).orElseThrow();
+
+    assertThat(environmentCount).isEqualTo(4L);
+    assertThat(foundReview.getEnvironments()).containsAllEntriesOf(environments);
+    assertThat(foundReview.getEditableUntil())
+        .isBetween(beforeCreate.plusDays(30), afterCreate.plusDays(30));
+  }
+
+  private Post createPost(Member member, Place place) {
+    return Post.of(
+        "스터디 기록",
+        "좋은 공간",
+        LocalDateTime.of(2026, 1, 1, 9, 0),
+        LocalDateTime.of(2026, 1, 1, 11, 0),
+        LocalDate.of(2026, 1, 1),
+        5,
+        PublicScope.PUBLIC,
+        member,
+        place,
+        PlaceCategoryCode.CAFE);
+  }
+}

--- a/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandServiceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandServiceTest.java
@@ -1,0 +1,115 @@
+package com.plog.plogbackend.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
+import com.plog.plogbackend.domain.place.entity.Place;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceReviewCommandServiceTest {
+
+  @Mock private PlaceReviewService placeReviewService;
+  @Mock private PlaceReviewImageService placeReviewImageService;
+  @Mock private PlaceReview placeReview;
+  @Mock private Post post;
+  @Mock private Place place;
+  @InjectMocks private PlaceReviewCommandService placeReviewCommandService;
+
+  @Test
+  @DisplayName("이미지 검증 후 리뷰를 생성하고 업로드된 이미지와 함께 응답한다")
+  void create_validatesImagesBeforeCreatingReviewAndUploadsImages() {
+    PlaceReviewCreateCommand command =
+        new PlaceReviewCreateCommand(1L, UUID.randomUUID(), 5, "좋았어요", environments());
+    List<MultipartFile> images =
+        List.of(new MockMultipartFile("images", "review.jpg", "image/jpeg", "review".getBytes()));
+    List<ImageUrlResponse> imageResponses =
+        List.of(new ImageUrlResponse("https://storage/review.jpg"));
+
+    given(placeReviewService.create(command)).willReturn(placeReview);
+    given(placeReview.getId()).willReturn(10L);
+    given(placeReview.getPost()).willReturn(post);
+    given(placeReview.getRating()).willReturn(5);
+    given(placeReview.getEnvironments()).willReturn(command.environments());
+    given(placeReview.getContent()).willReturn("좋았어요");
+    given(post.getId()).willReturn(1L);
+    given(post.getPlace()).willReturn(place);
+    given(post.getStudyDate()).willReturn(LocalDate.of(2026, 1, 1));
+    given(post.getStartedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 9, 0));
+    given(post.getEndedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 11, 0));
+    given(place.getId()).willReturn(2L);
+    given(place.getName()).willReturn("테스트 카페");
+    given(placeReviewImageService.uploadPlaceReviewImages(placeReview.getId(), images))
+        .willReturn(imageResponses);
+
+    PlaceReviewResponse response = placeReviewCommandService.create(command, images);
+
+    assertThat(response.imageUrls()).containsExactly("https://storage/review.jpg");
+    InOrder inOrder = inOrder(placeReviewImageService, placeReviewService);
+    inOrder.verify(placeReviewImageService).validateImages(images);
+    inOrder.verify(placeReviewService).create(command);
+    inOrder.verify(placeReviewImageService).uploadPlaceReviewImages(placeReview.getId(), images);
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 후 기존 이미지와 함께 응답한다")
+  void update_returnsUpdatedReviewWithImages() {
+    PlaceReviewUpdateCommand command =
+        new PlaceReviewUpdateCommand(10L, UUID.randomUUID(), 4, "수정했어요", environments());
+    List<ImageUrlResponse> imageResponses =
+        List.of(new ImageUrlResponse("https://storage/existing-review.jpg"));
+
+    given(placeReviewService.update(command)).willReturn(placeReview);
+    given(placeReview.getId()).willReturn(10L);
+    given(placeReview.getPost()).willReturn(post);
+    given(placeReview.getRating()).willReturn(4);
+    given(placeReview.getEnvironments()).willReturn(command.environments());
+    given(placeReview.getContent()).willReturn("수정했어요");
+    given(post.getId()).willReturn(1L);
+    given(post.getPlace()).willReturn(place);
+    given(post.getStudyDate()).willReturn(LocalDate.of(2026, 1, 1));
+    given(post.getStartedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 9, 0));
+    given(post.getEndedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 11, 0));
+    given(place.getId()).willReturn(2L);
+    given(place.getName()).willReturn("테스트 카페");
+    given(placeReviewImageService.getPlaceReviewImages(placeReview.getId()))
+        .willReturn(imageResponses);
+
+    PlaceReviewResponse response = placeReviewCommandService.update(command);
+
+    assertThat(response.rating()).isEqualTo(4);
+    assertThat(response.content()).isEqualTo("수정했어요");
+    assertThat(response.imageUrls()).containsExactly("https://storage/existing-review.jpg");
+  }
+
+  private Map<ReviewEnvironmentName, Integer> environments() {
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, 5);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, 4);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, 3);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, 2);
+    return environments;
+  }
+}

--- a/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandServiceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
 import com.plog.plogbackend.domain.review.entity.PlaceReview;
 import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -61,7 +62,7 @@ class PlaceReviewCommandServiceTest {
     given(post.getEndedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 11, 0));
     given(place.getId()).willReturn(2L);
     given(place.getName()).willReturn("테스트 카페");
-    given(placeReviewImageService.uploadPlaceReviewImages(placeReview.getId(), images))
+    given(placeReviewImageService.replacePlaceReviewImages(placeReview.getId(), List.of(), images))
         .willReturn(imageResponses);
 
     PlaceReviewResponse response = placeReviewCommandService.create(command, images);
@@ -70,14 +71,19 @@ class PlaceReviewCommandServiceTest {
     InOrder inOrder = inOrder(placeReviewImageService, placeReviewService);
     inOrder.verify(placeReviewImageService).validateImages(images);
     inOrder.verify(placeReviewService).create(command);
-    inOrder.verify(placeReviewImageService).uploadPlaceReviewImages(placeReview.getId(), images);
+    inOrder
+        .verify(placeReviewImageService)
+        .replacePlaceReviewImages(placeReview.getId(), List.of(), images);
   }
 
   @Test
   @DisplayName("리뷰 수정 후 기존 이미지와 함께 응답한다")
   void update_returnsUpdatedReviewWithImages() {
     PlaceReviewUpdateCommand command =
-        new PlaceReviewUpdateCommand(10L, UUID.randomUUID(), 4, "수정했어요", environments());
+        new PlaceReviewUpdateCommand(
+            10L, UUID.randomUUID(), 4, "수정했어요", environments(), List.of(1L));
+    List<MultipartFile> images =
+        List.of(new MockMultipartFile("images", "new.jpg", "image/jpeg", "new".getBytes()));
     List<ImageUrlResponse> imageResponses =
         List.of(new ImageUrlResponse("https://storage/existing-review.jpg"));
 
@@ -94,14 +100,24 @@ class PlaceReviewCommandServiceTest {
     given(post.getEndedAt()).willReturn(LocalDateTime.of(2026, 1, 1, 11, 0));
     given(place.getId()).willReturn(2L);
     given(place.getName()).willReturn("테스트 카페");
-    given(placeReviewImageService.getPlaceReviewImages(placeReview.getId()))
+    given(placeReviewImageService.replacePlaceReviewImages(10L, List.of(1L), images))
         .willReturn(imageResponses);
 
-    PlaceReviewResponse response = placeReviewCommandService.update(command);
+    PlaceReviewResponse response = placeReviewCommandService.update(command, images);
 
     assertThat(response.rating()).isEqualTo(4);
     assertThat(response.content()).isEqualTo("수정했어요");
     assertThat(response.imageUrls()).containsExactly("https://storage/existing-review.jpg");
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 삭제를 서비스에 위임한다")
+  void delete_delegatesToPlaceReviewService() {
+    PlaceReviewDeleteCommand command = new PlaceReviewDeleteCommand(10L, UUID.randomUUID());
+
+    placeReviewCommandService.delete(command);
+
+    inOrder(placeReviewService).verify(placeReviewService).delete(command);
   }
 
   private Map<ReviewEnvironmentName, Integer> environments() {

--- a/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageServiceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageServiceTest.java
@@ -14,6 +14,7 @@ import com.plog.plogbackend.domain.review.entity.PlaceReview;
 import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
 import com.plog.plogbackend.domain.review.repository.PlaceReviewImageRepository;
 import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
 import com.plog.plogbackend.global.util.GcsService;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,7 +54,8 @@ class PlaceReviewImageServiceTest {
         List.of(
             new MockMultipartFile("images", "a.jpg", "image/jpeg", "a".getBytes()),
             new MockMultipartFile("images", "b.jpg", "image/jpeg", "b".getBytes()));
-    given(placeReviewRepository.findById(reviewId)).willReturn(Optional.of(placeReview));
+    given(placeReviewRepository.findByIdAndStatus(reviewId, EntityStatus.ACTIVE))
+        .willReturn(Optional.of(placeReview));
     given(gcsService.upload(any(MultipartFile.class), eq("place-reviews")))
         .willReturn("https://storage/review-a.jpg", "https://storage/review-b.jpg");
 
@@ -63,7 +66,62 @@ class PlaceReviewImageServiceTest {
         .extracting(ImageUrlResponse::imageUrl)
         .containsExactly("https://storage/review-a.jpg", "https://storage/review-b.jpg");
     verify(placeReviewImageRepository, times(2)).save(any(PlaceReviewImage.class));
-    verify(placeReviewRepository).findById(reviewId);
+    verify(placeReviewRepository).findByIdAndStatus(reviewId, EntityStatus.ACTIVE);
     verify(gcsService, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("리뷰 이미지를 keep + new 조합으로 교체한다")
+  void replacePlaceReviewImages() {
+    Long reviewId = 1L;
+    PlaceReviewImage keepImage = PlaceReviewImage.of(placeReview, "https://storage/keep.jpg");
+    PlaceReviewImage deleteImage = PlaceReviewImage.of(placeReview, "https://storage/delete.jpg");
+    ReflectionTestUtils.setField(keepImage, "id", 10L);
+    ReflectionTestUtils.setField(deleteImage, "id", 20L);
+    List<MultipartFile> newImages =
+        List.of(new MockMultipartFile("images", "new.jpg", "image/jpeg", "new".getBytes()));
+    given(placeReviewRepository.findByIdAndStatus(reviewId, EntityStatus.ACTIVE))
+        .willReturn(Optional.of(placeReview));
+    given(placeReviewImageRepository.findAllByPlaceReviewId(reviewId))
+        .willReturn(List.of(keepImage, deleteImage));
+    given(gcsService.upload(any(MultipartFile.class), eq("place-reviews")))
+        .willReturn("https://storage/new.jpg");
+
+    List<ImageUrlResponse> responses =
+        placeReviewImageService.replacePlaceReviewImages(reviewId, List.of(10L), newImages);
+
+    assertThat(responses)
+        .extracting(ImageUrlResponse::imageUrl)
+        .containsExactly("https://storage/keep.jpg", "https://storage/new.jpg");
+    verify(gcsService).delete("https://storage/delete.jpg");
+    verify(placeReviewImageRepository).delete(deleteImage);
+    verify(placeReviewImageRepository).save(any(PlaceReviewImage.class));
+  }
+
+  @Test
+  @DisplayName("신규 이미지 업로드 실패 시 기존 GCS 이미지는 삭제하지 않고 업로드된 신규 이미지만 정리한다")
+  void replacePlaceReviewImages_whenUploadFails_keepsExistingGcsImages() {
+    Long reviewId = 1L;
+    PlaceReviewImage deleteImage = PlaceReviewImage.of(placeReview, "https://storage/delete.jpg");
+    ReflectionTestUtils.setField(deleteImage, "id", 20L);
+    List<MultipartFile> newImages =
+        List.of(
+            new MockMultipartFile("images", "new-a.jpg", "image/jpeg", "new-a".getBytes()),
+            new MockMultipartFile("images", "new-b.jpg", "image/jpeg", "new-b".getBytes()));
+    given(placeReviewRepository.findByIdAndStatus(reviewId, EntityStatus.ACTIVE))
+        .willReturn(Optional.of(placeReview));
+    given(placeReviewImageRepository.findAllByPlaceReviewId(reviewId))
+        .willReturn(List.of(deleteImage));
+    given(gcsService.upload(any(MultipartFile.class), eq("place-reviews")))
+        .willReturn("https://storage/new-a.jpg")
+        .willThrow(new RuntimeException("upload failed"));
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> placeReviewImageService.replacePlaceReviewImages(reviewId, List.of(), newImages))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(gcsService, never()).delete("https://storage/delete.jpg");
+    verify(gcsService).delete("https://storage/new-a.jpg");
+    verify(placeReviewImageRepository, never()).delete(deleteImage);
   }
 }

--- a/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageServiceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageServiceTest.java
@@ -1,0 +1,69 @@
+package com.plog.plogbackend.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.plog.plogbackend.domain.image.dto.ImageUrlResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewImageRepository;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.global.util.GcsService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceReviewImageServiceTest {
+
+  @Mock private GcsService gcsService;
+  @Mock private PlaceReviewRepository placeReviewRepository;
+  @Mock private PlaceReviewImageRepository placeReviewImageRepository;
+  @Mock private PlaceReview placeReview;
+  @InjectMocks private PlaceReviewImageService placeReviewImageService;
+
+  @Test
+  @DisplayName("리뷰 이미지가 없으면 업로드하지 않고 빈 목록을 반환한다")
+  void uploadPlaceReviewImages_withoutImages() {
+    List<ImageUrlResponse> responses = placeReviewImageService.uploadPlaceReviewImages(1L, null);
+
+    assertThat(responses).isEmpty();
+    verifyNoInteractions(gcsService, placeReviewRepository, placeReviewImageRepository);
+  }
+
+  @Test
+  @DisplayName("리뷰 이미지를 업로드하고 이미지 URL 응답을 반환한다")
+  void uploadPlaceReviewImages() {
+    Long reviewId = 1L;
+    List<MultipartFile> images =
+        List.of(
+            new MockMultipartFile("images", "a.jpg", "image/jpeg", "a".getBytes()),
+            new MockMultipartFile("images", "b.jpg", "image/jpeg", "b".getBytes()));
+    given(placeReviewRepository.findById(reviewId)).willReturn(Optional.of(placeReview));
+    given(gcsService.upload(any(MultipartFile.class), eq("place-reviews")))
+        .willReturn("https://storage/review-a.jpg", "https://storage/review-b.jpg");
+
+    List<ImageUrlResponse> responses =
+        placeReviewImageService.uploadPlaceReviewImages(reviewId, images);
+
+    assertThat(responses)
+        .extracting(ImageUrlResponse::imageUrl)
+        .containsExactly("https://storage/review-a.jpg", "https://storage/review-b.jpg");
+    verify(placeReviewImageRepository, times(2)).save(any(PlaceReviewImage.class));
+    verify(placeReviewRepository).findById(reviewId);
+    verify(gcsService, never()).delete(any());
+  }
+}

--- a/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewServiceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/service/PlaceReviewServiceTest.java
@@ -1,0 +1,149 @@
+package com.plog.plogbackend.domain.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.plog.plogbackend.domain.member.Member;
+import com.plog.plogbackend.domain.member.repository.MemberRepository;
+import com.plog.plogbackend.domain.post.entity.Post;
+import com.plog.plogbackend.domain.post.repository.PostRepository;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
+import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
+import com.plog.plogbackend.global.common.Enum.EntityStatus;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceReviewServiceTest {
+
+  @Mock private MemberRepository memberRepository;
+  @Mock private PostRepository postRepository;
+  @Mock private PlaceReviewRepository placeReviewRepository;
+  @Mock private Member member;
+  @Mock private Post post;
+  @InjectMocks private PlaceReviewService placeReviewService;
+
+  @Test
+  @DisplayName("삭제된 장소 리뷰가 있으면 새로 저장하지 않고 기존 리뷰를 복구해 덮어쓴다")
+  void create_deletedReview_restoresExistingReview() {
+    UUID memberKey = UUID.randomUUID();
+    PlaceReviewCreateCommand command =
+        new PlaceReviewCreateCommand(1L, memberKey, 3, "다시 작성", environments());
+    PlaceReview deletedReview =
+        PlaceReview.create(post, member, 5, "삭제된 리뷰", environments(5, 5, 5, 5));
+    deletedReview.delete();
+    given(member.getId()).willReturn(1L);
+    given(post.getMember()).willReturn(member);
+    given(memberRepository.findByMemberKey(memberKey)).willReturn(Optional.of(member));
+    given(postRepository.findById(command.postId())).willReturn(Optional.of(post));
+    given(placeReviewRepository.findByPostId(command.postId()))
+        .willReturn(Optional.of(deletedReview));
+
+    PlaceReview review = placeReviewService.create(command);
+
+    assertThat(review).isSameAs(deletedReview);
+    assertThat(review.getStatus()).isEqualTo(EntityStatus.ACTIVE);
+    assertThat(review.getDeletedAt()).isNull();
+    assertThat(review.getRating()).isEqualTo(3);
+    assertThat(review.getContent()).isEqualTo("다시 작성");
+    assertThat(review.getEnvironments()).containsExactlyInAnyOrderEntriesOf(command.environments());
+    verify(placeReviewRepository, never()).save(review);
+  }
+
+  @Test
+  @DisplayName("활성 장소 리뷰가 이미 있으면 중복 작성 예외를 던진다")
+  void create_activeReview_throwsAlreadyExists() {
+    UUID memberKey = UUID.randomUUID();
+    PlaceReviewCreateCommand command =
+        new PlaceReviewCreateCommand(1L, memberKey, 3, "다시 작성", environments());
+    PlaceReview activeReview = PlaceReview.create(post, member, 5, "기존 리뷰", environments());
+    given(member.getId()).willReturn(1L);
+    given(post.getMember()).willReturn(member);
+    given(memberRepository.findByMemberKey(memberKey)).willReturn(Optional.of(member));
+    given(postRepository.findById(command.postId())).willReturn(Optional.of(post));
+    given(placeReviewRepository.findByPostId(command.postId()))
+        .willReturn(Optional.of(activeReview));
+
+    assertThatThrownBy(() -> placeReviewService.create(command))
+        .isInstanceOf(AppException.class)
+        .extracting("errorType")
+        .isEqualTo(ErrorType.PLACE_REVIEW_ALREADY_EXISTS);
+  }
+
+  @Test
+  @DisplayName("삭제된 장소 리뷰는 수정 대상에서 제외한다")
+  void update_deletedReview_throwsNotFound() {
+    PlaceReviewUpdateCommand command =
+        new PlaceReviewUpdateCommand(1L, UUID.randomUUID(), 4, "수정", environments(), List.of());
+    given(placeReviewRepository.findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> placeReviewService.update(command))
+        .isInstanceOf(AppException.class)
+        .extracting("errorType")
+        .isEqualTo(ErrorType.NOT_FOUND);
+
+    verify(placeReviewRepository).findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE);
+  }
+
+  @Test
+  @DisplayName("장소 리뷰 삭제 시 활성 리뷰를 삭제 상태로 변경한다")
+  void delete_activeReview_marksReviewDeleted() {
+    UUID memberKey = UUID.randomUUID();
+    PlaceReviewDeleteCommand command = new PlaceReviewDeleteCommand(10L, memberKey);
+    given(member.getMemberKey()).willReturn(memberKey);
+    PlaceReview review = PlaceReview.create(post, member, 5, "좋았어요", environments());
+    given(placeReviewRepository.findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE))
+        .willReturn(Optional.of(review));
+
+    placeReviewService.delete(command);
+
+    assertThat(review.getStatus()).isEqualTo(EntityStatus.DELETED);
+    assertThat(review.getDeletedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("이미 삭제된 장소 리뷰는 삭제 대상에서 제외한다")
+  void delete_deletedReview_throwsNotFound() {
+    PlaceReviewDeleteCommand command = new PlaceReviewDeleteCommand(10L, UUID.randomUUID());
+    given(placeReviewRepository.findByIdAndStatus(command.reviewId(), EntityStatus.ACTIVE))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> placeReviewService.delete(command))
+        .isInstanceOf(AppException.class)
+        .extracting("errorType")
+        .isEqualTo(ErrorType.NOT_FOUND);
+  }
+
+  private Map<ReviewEnvironmentName, Integer> environments() {
+    return environments(5, 4, 3, 2);
+  }
+
+  private Map<ReviewEnvironmentName, Integer> environments(
+      int spaceSize, int noiseLevel, int congestionLevel, int focusLevel) {
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, spaceSize);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, noiseLevel);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, congestionLevel);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, focusLevel);
+    return environments;
+  }
+}


### PR DESCRIPTION
## PR 체크리스트

- [x] `PlaceReview` 생성 API가 정상 동작한다.
- [x] `PlaceReview` 수정 API가 정상 동작한다.
- [x] 리뷰 수정은 생성 후 30일 이내에만 가능하다.
- [x] 30일이 지난 리뷰 수정 시 적절한 예외가 발생한다.
- [x] 리뷰 삭제는 실제 DB row 삭제가 아니라 soft delete 정책을 따른다.
- [x] 리뷰 환경 점수는 `PlaceReviewEnvironment` 엔티티로 저장된다.
- [x] 리뷰 이미지 업로드 실패 시 이미 업로드된 GCS 파일이 정리된다.
- [x] 리뷰 생성 시 이미지 개수 제한이 리뷰 저장 전에 검증된다.
- [x] `PlaceReviewCommandService`가 생성/수정 유스케이스를 담당한다.
- [x] `PlaceReviewService`는 리뷰 도메인 생성/수정 로직만 담당한다.
- [x] Swagger 문서에 장소 리뷰 생성/수정 API가 반영되어 있다.
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew spotlessCheck` 통과
- [x] `./gradlew test` 통과
