### PR TITLE
chore: review 도메인 images 최대 갯수 5개로 변경 및 /edit 수정 엔드포인트 생성 

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
@@ -30,13 +30,13 @@ public class PlaceReviewController {
 
   private final PlaceReviewCommandService placeReviewCommandService;
 
-  @Operation(summary = "장소 리뷰 생성", description = "장소 리뷰 정보와 이미지를 함께 업로드합니다. (이미지 최대 3개)")
+  @Operation(summary = "장소 리뷰 생성", description = "장소 리뷰 정보와 이미지를 함께 업로드합니다. (이미지 최대 5개)")
   @PostMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ApiResponse<PlaceReviewResponse>> createReview(
       @PathVariable Long postId,
       @Parameter(description = "장소 리뷰 텍스트 데이터") @RequestPart("request") @Valid
           PlaceReviewCreateRequest request,
-      @Parameter(description = "장소 리뷰 이미지 (최대 3개)") @RequestPart(value = "images", required = false)
+      @Parameter(description = "장소 리뷰 이미지 (최대 5개)") @RequestPart(value = "images", required = false)
           List<MultipartFile> images,
       @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
     PlaceReviewCreateCommand command = PlaceReviewMapper.from(postId, request, memberKey);

--- a/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/controller/PlaceReviewController.java
@@ -3,8 +3,10 @@ package com.plog.plogbackend.domain.review.controller;
 import com.plog.plogbackend.domain.review.controller.api.PlaceReviewMapper;
 import com.plog.plogbackend.domain.review.dto.request.PlaceReviewCreateRequest;
 import com.plog.plogbackend.domain.review.dto.request.PlaceReviewUpdateRequest;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewQueryResponse;
 import com.plog.plogbackend.domain.review.dto.response.PlaceReviewResponse;
 import com.plog.plogbackend.domain.review.service.PlaceReviewCommandService;
+import com.plog.plogbackend.domain.review.service.PlaceReviewQueryService;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewCreateCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewDeleteCommand;
 import com.plog.plogbackend.domain.review.service.dto.PlaceReviewUpdateCommand;
@@ -29,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PlaceReviewController {
 
   private final PlaceReviewCommandService placeReviewCommandService;
+  private final PlaceReviewQueryService placeReviewQueryService;
 
   @Operation(summary = "장소 리뷰 생성", description = "장소 리뷰 정보와 이미지를 함께 업로드합니다. (이미지 최대 5개)")
   @PostMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -45,17 +48,27 @@ public class PlaceReviewController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
+  @Operation(summary = "수정용 장소 리뷰 조회", description = "본인의 장소 리뷰 수정 폼에 표시할 데이터를 조회합니다.")
+  @GetMapping("/{reviewId}/edit")
+  public ResponseEntity<ApiResponse<PlaceReviewQueryResponse>> getEditReview(
+      @Parameter(description = "장소 리뷰 ID") @PathVariable Long reviewId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
+    PlaceReviewQueryResponse placeReview =
+        placeReviewQueryService.getPlaceReview(reviewId, memberKey);
+    return ResponseEntity.ok(ApiResponse.success(placeReview));
+  }
+
   @Operation(
       summary = "장소 리뷰 수정",
       description =
           "장소 리뷰 별점, 환경 점수, 내용과 이미지를 수정합니다. keepImageIds로 유지할 기존 이미지를 지정하고, "
-              + "images로 새 이미지를 업로드합니다. (작성 후 30일 이내, 총합 3개 이하)")
+              + "images로 새 이미지를 업로드합니다. (작성 후 30일 이내, 총합 5개 이하)")
   @PutMapping(value = "/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ApiResponse<PlaceReviewResponse>> updateReview(
-      @PathVariable Long reviewId,
+      @Parameter(description = "장소 리뷰 ID") @PathVariable Long reviewId,
       @Parameter(description = "장소 리뷰 수정 데이터") @RequestPart("request") @Valid
           PlaceReviewUpdateRequest request,
-      @Parameter(description = "새로 추가된 리뷰 이미지 (옵션)")
+      @Parameter(description = "새로 추가할 리뷰 이미지 (옵션, 유지 이미지와 합산 최대 5개)")
           @RequestPart(value = "images", required = false)
           List<MultipartFile> images,
       @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
@@ -68,7 +81,7 @@ public class PlaceReviewController {
   @Operation(summary = "장소 리뷰 삭제", description = "본인 장소 리뷰를 삭제 상태로 변경합니다.")
   @DeleteMapping("/{reviewId}")
   public ResponseEntity<ApiResponse<Void>> deleteReview(
-      @PathVariable Long reviewId,
+      @Parameter(description = "장소 리뷰 ID") @PathVariable Long reviewId,
       @Parameter(hidden = true) @AuthenticationPrincipal UUID memberKey) {
     PlaceReviewDeleteCommand command = PlaceReviewMapper.from(reviewId, memberKey);
     placeReviewCommandService.delete(command);

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewImageResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewImageResponse.java
@@ -1,0 +1,22 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import java.util.List;
+
+public record PlaceReviewImageResponse(List<PlaceReviewImageItem> images, int total) {
+
+  public static PlaceReviewImageResponse from(List<PlaceReviewImage> images) {
+    if (images == null || images.isEmpty()) {
+      return new PlaceReviewImageResponse(List.of(), 0);
+    }
+
+    List<PlaceReviewImageItem> items = images.stream().map(PlaceReviewImageItem::from).toList();
+    return new PlaceReviewImageResponse(items, items.size());
+  }
+
+  public record PlaceReviewImageItem(Long id, String url) {
+    public static PlaceReviewImageItem from(PlaceReviewImage image) {
+      return new PlaceReviewImageItem(image.getId(), image.getImageUrl());
+    }
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewQueryResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewQueryResponse.java
@@ -1,0 +1,10 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+public record PlaceReviewQueryResponse(
+    PlaceReviewRequestPartResponse review, PlaceReviewImageResponse images) {
+
+  public static PlaceReviewQueryResponse of(
+      PlaceReviewRequestPartResponse review, PlaceReviewImageResponse images) {
+    return new PlaceReviewQueryResponse(review, images);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewRequestPartResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewRequestPartResponse.java
@@ -1,0 +1,37 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+import com.plog.plogbackend.domain.post.controller.dto.response.TimePickerResponse;
+import com.plog.plogbackend.domain.post.entity.PostImage;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import java.time.LocalDate;
+import java.util.Comparator;
+
+public record PlaceReviewRequestPartResponse(
+    String placeProfileUrl,
+    String placeName,
+    Integer rating,
+    LocalDate studyDate,
+    TimePickerResponse startedAt,
+    TimePickerResponse endedAt,
+    String content,
+    ReviewEnvironmentResponse environments) {
+
+  public static PlaceReviewRequestPartResponse from(PlaceReview placeReview) {
+    return new PlaceReviewRequestPartResponse(
+        firstPostImageUrl(placeReview),
+        placeReview.getPost().getPlace().getName(),
+        placeReview.getRating(),
+        placeReview.getPost().getStudyDate(),
+        TimePickerResponse.from(placeReview.getPost().getStartedAt()),
+        TimePickerResponse.from(placeReview.getPost().getEndedAt()),
+        placeReview.getContent(),
+        ReviewEnvironmentResponse.from(placeReview));
+  }
+
+  private static String firstPostImageUrl(PlaceReview placeReview) {
+    return placeReview.getPost().getImages().stream()
+        .min(Comparator.comparing(PostImage::getId, Comparator.nullsLast(Long::compareTo)))
+        .map(PostImage::getImageUrl)
+        .orElse(null);
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/dto/response/ReviewEnvironmentResponse.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/dto/response/ReviewEnvironmentResponse.java
@@ -1,0 +1,16 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.enums.ReviewEnvironmentName;
+
+public record ReviewEnvironmentResponse(
+    Integer spaceSize, Integer noiseLevel, Integer congestionLevel, Integer focusLevel) {
+
+  public static ReviewEnvironmentResponse from(PlaceReview placeReview) {
+    return new ReviewEnvironmentResponse(
+        placeReview.getEnvironments().get(ReviewEnvironmentName.SPACE_SIZE),
+        placeReview.getEnvironments().get(ReviewEnvironmentName.NOISE_LEVEL),
+        placeReview.getEnvironments().get(ReviewEnvironmentName.CONGESTION_LEVEL),
+        placeReview.getEnvironments().get(ReviewEnvironmentName.FOCUS_LEVEL));
+  }
+}

--- a/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/repository/PlaceReviewImageRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface PlaceReviewImageRepository extends JpaRepository<PlaceReviewImage, Long> {
   List<PlaceReviewImage> findAllByPlaceReviewId(Long placeReviewId);
 
+  List<PlaceReviewImage> findAllByPlaceReviewIdOrderByIdAsc(Long placeReviewId);
+
   @Modifying
   @Query(
       """

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewImageService.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PlaceReviewImageService {
 
   private static final String PLACE_REVIEW_DIR = "place-reviews";
-  private static final int PLACE_REVIEW_IMAGE_MAX = 3;
+  private static final int PLACE_REVIEW_IMAGE_MAX = 5;
 
   private final GcsService gcsService;
   private final PlaceReviewRepository placeReviewRepository;

--- a/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewQueryService.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/service/PlaceReviewQueryService.java
@@ -1,0 +1,48 @@
+package com.plog.plogbackend.domain.review.service;
+
+import static com.plog.plogbackend.global.common.Enum.EntityStatus.ACTIVE;
+
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewImageResponse;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewQueryResponse;
+import com.plog.plogbackend.domain.review.dto.response.PlaceReviewRequestPartResponse;
+import com.plog.plogbackend.domain.review.entity.PlaceReview;
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewImageRepository;
+import com.plog.plogbackend.domain.review.repository.PlaceReviewRepository;
+import com.plog.plogbackend.global.error.AppException;
+import com.plog.plogbackend.global.error.ErrorType;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceReviewQueryService {
+
+  private final PlaceReviewRepository placeReviewRepository;
+  private final PlaceReviewImageRepository placeReviewImageRepository;
+
+  public PlaceReviewQueryResponse getPlaceReview(Long reviewId, UUID memberKey) {
+
+    PlaceReview placeReview = findPlaceReview(reviewId);
+
+    if (!placeReview.getMember().getMemberKey().equals(memberKey)) {
+      throw new AppException(ErrorType.POST_FORBIDDEN);
+    }
+
+    List<PlaceReviewImage> images =
+        placeReviewImageRepository.findAllByPlaceReviewIdOrderByIdAsc(reviewId);
+
+    return PlaceReviewQueryResponse.of(
+        PlaceReviewRequestPartResponse.from(placeReview), PlaceReviewImageResponse.from(images));
+  }
+
+  private PlaceReview findPlaceReview(Long placeId) {
+    return placeReviewRepository
+        .findByIdAndStatus(placeId, ACTIVE)
+        .orElseThrow(() -> new AppException(ErrorType.PLACE_REVIEW_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
+++ b/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
@@ -105,7 +105,7 @@ public enum ErrorType {
   PLACE_REVIEW_EDIT_PERIOD_EXPIRED(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "장소 리뷰 수정 가능 기간이 만료되었습니다.", LogLevel.WARN),
   PLACE_REVIEW_IMAGE_LIMIT_EXCEEDED(
-      HttpStatus.BAD_REQUEST, ErrorCode.E1106, "장소 리뷰 이미지는 최대 3개까지 업로드 가능합니다.", LogLevel.WARN);
+      HttpStatus.BAD_REQUEST, ErrorCode.E1106, "장소 리뷰 이미지는 최대 5개까지 업로드 가능합니다.", LogLevel.WARN);
 
   // 여기에 추가해주시고 사용하시면 됩니다.
 

--- a/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
+++ b/src/main/java/com/plog/plogbackend/global/error/ErrorType.java
@@ -100,6 +100,8 @@ public enum ErrorType {
       HttpStatus.FORBIDDEN, ErrorCode.E403, "본인의 검색 이력만 삭제할 수 있습니다.", LogLevel.WARN),
 
   // 장소 리뷰 관련
+  PLACE_REVIEW_NOT_FOUND(
+      HttpStatus.NOT_FOUND, ErrorCode.E404, "저장된 장소 리뷰 값과 일치하지 않습니다.", LogLevel.WARN),
   PLACE_REVIEW_ALREADY_EXISTS(
       HttpStatus.CONFLICT, ErrorCode.E409, "이미 작성된 장소 리뷰가 있습니다.", LogLevel.WARN),
   PLACE_REVIEW_EDIT_PERIOD_EXPIRED(

--- a/src/test/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewImageResponseTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/dto/response/PlaceReviewImageResponseTest.java
@@ -1,0 +1,35 @@
+package com.plog.plogbackend.domain.review.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.plog.plogbackend.domain.review.entity.PlaceReviewImage;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PlaceReviewImageResponseTest {
+
+  @Test
+  @DisplayName("리뷰 이미지가 없으면 빈 이미지 응답을 만든다")
+  void from_nullImages_returnsEmptyResponse() {
+    PlaceReviewImageResponse response = PlaceReviewImageResponse.from(null);
+
+    assertThat(response.images()).isEmpty();
+    assertThat(response.total()).isZero();
+  }
+
+  @Test
+  @DisplayName("리뷰 이미지 ID와 URL을 수정 폼 응답으로 변환한다")
+  void from_convertsImageIdAndUrl() {
+    PlaceReviewImage image = PlaceReviewImage.of(null, "https://storage/review.jpg");
+    ReflectionTestUtils.setField(image, "id", 10L);
+
+    PlaceReviewImageResponse response = PlaceReviewImageResponse.from(List.of(image));
+
+    assertThat(response.total()).isEqualTo(1);
+    assertThat(response.images()).hasSize(1);
+    assertThat(response.images().get(0).id()).isEqualTo(10L);
+    assertThat(response.images().get(0).url()).isEqualTo("https://storage/review.jpg");
+  }
+}


### PR DESCRIPTION
reveiw 도메인의 images 최대 갯수를 5개로 변경 및 /edit 수정 엔드포인트를 구현할 예정입니다. 

- [x] images 최대 갯수 5개로 변경
- [x] /edit 엔드 포인트 구현 