### PR TITLE
fix: 장소 리뷰 수정 시 환경 점수 중복 삽입 오류 수정

### DIFF
--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReview.java
@@ -96,8 +96,7 @@ public class PlaceReview extends BaseTimeStatusEntity {
     validateEditable(now);
     this.rating = rating;
     this.content = content;
-    this.environments.clear();
-    addEnvironments(environments);
+    replaceEnvironments(environments);
   }
 
   public void delete() {
@@ -113,8 +112,7 @@ public class PlaceReview extends BaseTimeStatusEntity {
     this.rating = rating;
     this.content = content;
     this.editableUntil = now.plusDays(EDITABLE_DAYS);
-    this.environments.clear();
-    addEnvironments(environments);
+    replaceEnvironments(environments);
   }
 
   public Map<ReviewEnvironmentName, Integer> getEnvironments() {
@@ -135,6 +133,28 @@ public class PlaceReview extends BaseTimeStatusEntity {
           if (name != null && score != null) {
             this.environments.add(PlaceReviewEnvironment.of(this, name, score));
           }
+        });
+  }
+
+  private void replaceEnvironments(Map<ReviewEnvironmentName, Integer> environments) {
+    if (environments == null || environments.isEmpty()) {
+      this.environments.clear();
+      return;
+    }
+
+    this.environments.removeIf(environment -> !environments.containsKey(environment.getName()));
+    environments.forEach(
+        (name, score) -> {
+          if (name == null || score == null) {
+            return;
+          }
+
+          this.environments.stream()
+              .filter(environment -> environment.getName() == name)
+              .findFirst()
+              .ifPresentOrElse(
+                  environment -> environment.updateScore(score),
+                  () -> this.environments.add(PlaceReviewEnvironment.of(this, name, score)));
         });
   }
 }

--- a/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironment.java
+++ b/src/main/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironment.java
@@ -43,4 +43,8 @@ public class PlaceReviewEnvironment {
       PlaceReview placeReview, ReviewEnvironmentName name, Integer score) {
     return new PlaceReviewEnvironment(placeReview, name, score);
   }
+
+  void updateScore(Integer score) {
+    this.score = score;
+  }
 }

--- a/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironmentPersistenceTest.java
+++ b/src/test/java/com/plog/plogbackend/domain/review/entity/PlaceReviewEnvironmentPersistenceTest.java
@@ -70,6 +70,29 @@ class PlaceReviewEnvironmentPersistenceTest {
         .isBetween(beforeCreate.plusDays(30), afterCreate.plusDays(30));
   }
 
+  @Test
+  @DisplayName("장소 리뷰 환경 점수 수정 시 기존 환경 엔티티를 중복 삽입하지 않고 갱신한다")
+  void updatePlaceReview_replacesEnvironmentEntitiesWithoutUniqueConstraintViolation() {
+    Member member =
+        memberRepository.save(Member.createNewMember("reviewer", "provider-reviewer", null, null));
+    Place place = placeRepository.save(Place.of("테스트 카페", "서울시 강남구", 37.0, 127.0));
+    Post post = postRepository.save(createPost(member, place));
+    PlaceReview review =
+        placeReviewRepository.save(
+            PlaceReview.create(post, member, 5, "집중하기 좋았어요", environments(5)));
+    em.flush();
+
+    review.update(3, "수정했어요", environments(3), LocalDateTime.now());
+    em.flush();
+    em.clear();
+
+    PlaceReview updatedReview = placeReviewRepository.findById(review.getId()).orElseThrow();
+
+    assertThat(updatedReview.getRating()).isEqualTo(3);
+    assertThat(updatedReview.getContent()).isEqualTo("수정했어요");
+    assertThat(updatedReview.getEnvironments()).containsAllEntriesOf(environments(3));
+  }
+
   private Post createPost(Member member, Place place) {
     return Post.of(
         "스터디 기록",
@@ -82,5 +105,14 @@ class PlaceReviewEnvironmentPersistenceTest {
         member,
         place,
         PlaceCategoryCode.CAFE);
+  }
+
+  private Map<ReviewEnvironmentName, Integer> environments(int score) {
+    Map<ReviewEnvironmentName, Integer> environments = new EnumMap<>(ReviewEnvironmentName.class);
+    environments.put(ReviewEnvironmentName.SPACE_SIZE, score);
+    environments.put(ReviewEnvironmentName.NOISE_LEVEL, score);
+    environments.put(ReviewEnvironmentName.CONGESTION_LEVEL, score);
+    environments.put(ReviewEnvironmentName.FOCUS_LEVEL, score);
+    return environments;
   }
 }


### PR DESCRIPTION
장소리뷰 환경에 의한 유니크 제약조건으로 인해 미리 Insert 시 키 중복으로 수정이 안되는 상황을 조치했습니다