### PR TITLE
chore: docker health check lazy 15m

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,6 +42,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 15m  # <--- 이 줄을 꼭 넣어주세요!
     networks:
       - app-tier
       - data-tier


### PR DESCRIPTION
cd에서 도커 health check가 너무 빨라서 cd가 실패하는것으로 추정되어 15m 연장 시켰습니다 